### PR TITLE
Array form を実装

### DIFF
--- a/src/demo/contents.json
+++ b/src/demo/contents.json
@@ -51,6 +51,16 @@
         "key": "title",
         "label": "タイトル",
         "type": "text"
+      },
+      {
+        "key": "tags",
+        "label": "タグ",
+        "type": "array",
+        "opts": {
+          "schema": {
+            "type": "text"
+          }
+        }
       }
     ],
     "headings": [

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -25,7 +25,7 @@
       button.mb16 save
       div.row.mxn8
         +each('schemas as schema')
-          div.px8.mb16(class='{schema.class}')
+          div.px8.mb16.w-full(class='{schema.class}')
             //- svelte:component(this='{forms[schema.type]}', value='{ getByPath(item, schema.key) }')
             svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{item[schema.key]}')
 </template>

--- a/src/lib/dummy.js
+++ b/src/lib/dummy.js
@@ -29,7 +29,7 @@ export function post() {
     title: faker.lorem.sentence(),
     description: faker.lorem.lines(),
     image: image(),
-    tag_names: [faker.lorem.word(), faker.lorem.word(), faker.lorem.word()],
+    tags: [faker.lorem.word(), faker.lorem.word(), faker.lorem.word()],
     created_user: user(),
     created_at: faker.datatype.datetime().getTime(),
     updated_at: faker.datatype.datetime().getTime(),

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -1,1 +1,25 @@
-<div>Todo Array</div>
+<svelte:options accessors={true}/>
+
+<script>
+  import { forms } from "$lib/index.js";
+
+  export let schema;
+  export let value = [''];
+
+  let add = () => {
+    value.push('');
+    value = value;
+  };
+
+</script>
+
+<template lang='pug'>
+  label.block
+    +if('schema.label')
+      div.fs12.mb4 {schema.label}
+    div
+      +each('value as i')
+        div.mb4
+          svelte:component(this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{i}')
+      button.button(type='button', on:click='{add}') add
+</template>

--- a/src/lib/forms/Text.svelte
+++ b/src/lib/forms/Text.svelte
@@ -2,11 +2,12 @@
 
 <script>
   export let schema;
-  export let value = 'hoge';
+  export let value = '';
 </script>
 
 <template lang='pug'>
   label.block
-    div.fs12.mb4 {schema.label}
+    +if('schema.label')
+      div.fs12.mb4 {schema.label}
     input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}')
 </template>

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -2,11 +2,12 @@
 
 <script>
   export let schema;
-  export let value = 'hoge';
+  export let value = '';
 </script>
 
 <template lang='pug'>
   label.block
-    div.fs12.mb4 {schema.label}
+    +if('schema.label')
+      div.fs12.mb4 {schema.label}
     textarea.w-full.border.px8.py4(bind:value, rows='8')
 </template>


### PR DESCRIPTION
## 対応内容

- Array form を実装
- posts の タグで確認できるよう対応

## 確認方法

- [ ] https://svelte-admin-cmp-pr-4.herokuapp.com/posts/00503d8b-b311-480f-b39a-e9e057eb809e にアクセス
- [ ] タグを編集して保存
- [ ] 内容がリロードしても保持されてれば OK

## リンク

- 確認URL ... https://svelte-admin-cmp-pr-4.herokuapp.com/posts/00503d8b-b311-480f-b39a-e9e057eb809e
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c941aj223akg02g7frq0)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/161377039-0cd93906-08cd-4d00-8325-1cf93d922ce9.png)
