### PR TITLE
Object form 対応

### DIFF
--- a/src/demo/contents.json
+++ b/src/demo/contents.json
@@ -61,6 +61,25 @@
             "type": "text"
           }
         }
+      },
+      {
+        "key": "meta",
+        "label": "メタ情報",
+        "type": "object",
+        "opts": {
+          "schemas": [
+            {
+              "key": "title",
+              "label": "タイトル",
+              "type": "text"
+            },
+            {
+              "key": "description",
+              "label": "詳細",
+              "type": "textarea"
+            }
+          ]
+        }
       }
     ],
     "headings": [

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -4,10 +4,10 @@
   import { forms } from "$lib/index.js";
 
   export let schema;
-  export let value = [''];
+  export let value = [{}];
 
   let add = () => {
-    value.push('');
+    value.push({});
     value = value;
   };
 

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -1,1 +1,18 @@
-<div>Todo Object</div>
+<svelte:options accessors={true}/>
+
+<script>
+  import { forms } from "$lib/index.js";
+
+  export let schema;
+  export let value = {};
+</script>
+
+<template lang='pug'>
+  div.border.p8
+    +if('schema.label')
+      div.fs12.mb4 {schema.label}
+    div.row.mxn8
+      +each('schema.opts.schemas as schema')
+        div.px8.mb16.w-full(class='{schema.class}')
+          svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{value[schema.key]}')
+</template>


### PR DESCRIPTION
## 対応内容

- Object form を実装
- posts の meta 情報で確認できるよう対応

## 確認方法

- [ ] https://svelte-admin-cmp-pr-5.herokuapp.com/posts/00503d8b-b311-480f-b39a-e9e057eb809e にアクセス
- [ ] meta 情報を編集して保存
- [ ] 内容がリロードしても保持されてれば OK

## リンク

- 確認URL ... https://svelte-admin-cmp-pr-5.herokuapp.com/posts/00503d8b-b311-480f-b39a-e9e057eb809e
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c956f0223akg02lrmgtg)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/161469794-723c3ef3-6d58-4056-bf07-296391244b32.png)
