### PR TITLE
contents.json(主に schema) を編集できるよう対応

### DIFF
--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -22,7 +22,8 @@
 <template lang='pug'>
   div(class='{className}')
     form(on:submit|preventDefault='{submit}')
-      button.mb16 save
+      div.f.fr
+        button.button.primary.mb16 save
       div.row.mxn8
         +each('schemas as schema')
           div.px8.mb16.w-full(class='{schema.class}')

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -4,11 +4,23 @@
   import { forms } from "$lib/index.js";
 
   export let schema;
-  export let value = [{}];
+  export let value = [_getDefaultValue()];
 
   let add = () => {
-    value.push({});
+    console.log(schema);
+    value.push(_getDefaultValue());
     value = value;
+  };
+
+  let _getDefaultValue = () => {
+    if (schema.type === 'object') {
+      return {};
+    }
+    else if (schema.type === 'array') {
+      return [];
+    }
+
+    return '';
   };
 
 </script>
@@ -21,5 +33,5 @@
       +each('value as i')
         div.mb4
           svelte:component(this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{i}')
-      button.button(type='button', on:click='{add}') add
+      button.button.w-full(type='button', on:click='{add}') +
 </template>

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -4,23 +4,17 @@
   import { forms } from "$lib/index.js";
 
   export let schema;
-  export let value = [_getDefaultValue()];
+  export let value;
+
+  // setup default value
+  if (!value) {
+    value = [''];
+  }
 
   let add = () => {
     console.log(schema);
-    value.push(_getDefaultValue());
+    value.push('');
     value = value;
-  };
-
-  let _getDefaultValue = () => {
-    if (schema.type === 'object') {
-      return {};
-    }
-    else if (schema.type === 'array') {
-      return [];
-    }
-
-    return '';
   };
 
 </script>

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -26,12 +26,14 @@
 </script>
 
 <template lang='pug'>
-  div.block
+  div.block.border
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    div
-      +each('value as i')
-        div.mb4
-          svelte:component(this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{i}')
+      div.bg-aliceblue.border-bottom.p8
+        div.fs12.mb4 {schema.label}
+    div.p16
+      div.mb8
+        +each('value as i')
+          div.mb8
+            svelte:component(this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{i}')
       button.button.w-full(type='button', on:click='{add}') +
 </template>

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <template lang='pug'>
-  label.block
+  div.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
     div

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -8,11 +8,12 @@
 </script>
 
 <template lang='pug'>
-  div.border.p8
+  div.border
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    div.row.mxn8
+      div.bg-aliceblue.border-bottom.p8
+        div.fs12.mb4 {schema.label}
+    div.row.p16.mxn8
       +each('schema.opts.schemas as schema')
-        div.px8.mb16.w-full(class='{schema.class}')
+        div.w-full.px8.mb16.mb0-last(class='{schema.class}')
           svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{value[schema.key]}')
 </template>

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -4,7 +4,12 @@
   import { forms } from "$lib/index.js";
 
   export let schema;
-  export let value = {};
+  export let value;
+
+  // setup default value
+  if (!value) {
+    value = {};
+  }
 </script>
 
 <template lang='pug'>

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -17,7 +17,7 @@
   }
 </script>
 <script>
-  import { ContentForm, Sidebar } from "$lib";
+  import { ContentForm, Sidebar } from "svelte-admin-components";
 
   export let collection;
   export let item;

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -15,8 +15,6 @@
 <script>
   import { ContentForm, Sidebar } from "svelte-admin-components";
 
-  export let collection;
-  export let item = {};
   export let content;
 
   let schemas = [

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -78,6 +78,6 @@
     Sidebar.w300.bg-royalblue.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        h1.mb16 {content.label} schema
+        h1.mb16 {content.label} edit
         ContentForm(item='{content}', schemas='{schemas}', on:submit='{submit}')
 </template>

--- a/src/routes/[collection]/index.svelte
+++ b/src/routes/[collection]/index.svelte
@@ -18,7 +18,7 @@
 <script>
   import { goto } from "$app/navigation";
 
-  import { ContentList, Sidebar } from "$lib";
+  import { ContentList, Sidebar } from "svelte-admin-components";
   
   export let items = [];
   export let content;

--- a/src/routes/[collection]/index.svelte
+++ b/src/routes/[collection]/index.svelte
@@ -35,7 +35,7 @@
       div.container-960.px16.py32
         div.f.fm.flex-between
           h1.mb16 {content.label}
-          a.fs12(href='/{content.path}/schema') edit
+          a.fs12(href='/{content.path}/edit') edit
 
         ContentList(items='{items}', headings='{content.headings}', on:select='{select}')
 </template>

--- a/src/routes/[collection]/index.svelte
+++ b/src/routes/[collection]/index.svelte
@@ -33,7 +33,9 @@
     Sidebar.w300.bg-royalblue.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        h1.mb16 {content.label}
+        div.f.fm.flex-between
+          h1.mb16 {content.label}
+          a.fs12(href='/{content.path}/schema') edit
 
         ContentList(items='{items}', headings='{content.headings}', on:select='{select}')
 </template>

--- a/src/routes/[collection]/schema.svelte
+++ b/src/routes/[collection]/schema.svelte
@@ -1,0 +1,85 @@
+<script context="module">
+  import admin from "$demo/admin.js"
+  export async function load({fetch, params}) {
+    let collection = params.collection;
+    let content = admin.contents[params.collection];
+
+    return {
+      props: {
+        collection,
+        content,
+      }
+    };
+  }
+</script>
+<script>
+  import { ContentForm, Sidebar } from "$lib";
+
+  export let collection;
+  export let item = {};
+  export let content;
+
+  let schemas = [
+    {
+      "key": "label",
+      "label": "label",
+      "type": "text",
+      "class": "col4",
+    },
+
+    {
+      "key": "schemas",
+      "label": "schemas",
+      "type": "array",
+      "opts": {
+        "schema": {
+          "type": "object",
+          "opts": {
+            "schemas": [
+              {
+                "key": "key",
+                "label": "key",
+                "type": "text",
+                "class": "col4",
+              },
+              {
+                "key": "label",
+                "label": "label",
+                "type": "text",
+                "class": "col4",
+              },
+              {
+                "key": "type",
+                "label": "type",
+                "type": "text",
+                "class": "col4",
+              },
+            ]
+          }
+        }
+      }
+    },
+  ];
+
+  let submit = async (e) => {
+    let item = e.detail.item;
+
+    await fetch('/api/contents', {
+      method: 'post',
+      body: JSON.stringify({
+        contents: admin.contents,
+      })
+    });
+
+    console.log('writed');
+  };
+</script>
+
+<template lang='pug'>
+  div.f
+    Sidebar.w300.bg-royalblue.text-white(sections='{admin.sections}')
+    main.w-full
+      div.container-960.px16.py32
+        h1.mb16 {content.label} schema
+        ContentForm(item='{content}', schemas='{schemas}', on:submit='{submit}')
+</template>

--- a/src/routes/[collection]/schema.svelte
+++ b/src/routes/[collection]/schema.svelte
@@ -13,7 +13,7 @@
   }
 </script>
 <script>
-  import { ContentForm, Sidebar } from "$lib";
+  import { ContentForm, Sidebar } from "svelte-admin-components";
 
   export let collection;
   export let item = {};

--- a/src/routes/api/contents.js
+++ b/src/routes/api/contents.js
@@ -1,0 +1,13 @@
+
+import fs from 'fs';
+
+export async function post({request, params, url}) {
+  let body = await request.json();
+
+  fs.writeFileSync('src/demo/contents.json', JSON.stringify(body.contents, null, '  '));
+
+  return {
+    body: {
+    }
+  };
+};

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,7 +1,7 @@
 <script context="module">
 </script>
 <script>
-  import Sidebar from "$lib/components/Sidebar.svelte";
+  import { Sidebar } from "svelte-admin-components";
   import admin from "$demo/admin.js"
 
 </script>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -23,6 +23,7 @@ const config = {
       },
       resolve: {
         alias: {
+          "svelte-admin-components": path.resolve('./src/lib'),
           $components: path.resolve('./src/components'),
           $demo: path.resolve('./src/demo'),
         }


### PR DESCRIPTION
## 対応内容

- contents.json を直接 form からいじれるよう対応する
- $app がバッティングしていたので $demo に変更

## 確認方法

※ローカルで動作確認してください

- [ ] http://localhost:3000/users/edit にアクセス
- [ ] スキーマを追加
- [ ] 実際にユーザー編集画面で項目が追加されてれば OK
- [ ] ローカルの contents.json にも反映されてれば OK

## リンク

- 確認URL ... http://localhost:3000/users/edit
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c9585va23akg02lrnjfg)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/161499615-df229acf-30b3-446b-9b67-71602987a0bf.png)
