### PR TITLE
新規作成に対応

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,7 @@
     <!-- <link rel="icon" href="%svelte.assets%/favicon.png" /> -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/phi-jp/meltline@v0.1.15/meltline.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     
     %svelte.head%
   </head>

--- a/src/demo/curd.js
+++ b/src/demo/curd.js
@@ -16,7 +16,22 @@ export const index = (key) => {
 
 // 
 export const create = (key) => {
+  let items = dummy[key];
+  let generator = dummy.generator[key];
 
+  return async function({request, params, url}) {
+    let item = generator();
+    let body = await request.json();
+    Object.assign(item, body.item);
+
+    items.unshift(item);
+
+    return {
+      body: {
+        item,
+      }
+    };
+  };
 };
 
 // 

--- a/src/demo/dummy.js
+++ b/src/demo/dummy.js
@@ -41,6 +41,12 @@ export function post() {
 let dummy = {
   users: Array(32).fill().map(() => user()),
   posts: Array(32).fill().map(() => post()),
+
+  generator: {
+    images: image,
+    users: user,
+    posts: post,
+  },
 };
 
 export default dummy;

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -3,7 +3,7 @@
   export async function load({fetch, params}) {
     let collection = params.collection;
     let id = params.id;
-    let content = admin.contents[params.collection];;
+    let content = admin.contents[params.collection];
     let item;
 
     if (params.id !== 'new') {

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -3,9 +3,17 @@
   export async function load({fetch, params}) {
     let collection = params.collection;
     let id = params.id;
-    let res = await fetch(`/api/${collection}/${id}`);
-    let {item} = await res.json();
-    let content = admin.contents[params.collection];
+    let content = admin.contents[params.collection];;
+    let item;
+
+    if (params.id !== 'new') {
+      let res = await fetch(`/api/${collection}/${id}`);
+      let data = await res.json();
+      item = data.item;
+    }
+    else {
+      item = {};
+    }
 
     return {
       props: {
@@ -17,6 +25,7 @@
   }
 </script>
 <script>
+  import { goto } from "$app/navigation";
   import { ContentForm, Sidebar } from "svelte-admin-components";
 
   export let collection;
@@ -26,13 +35,31 @@
   let submit = async (e) => {
     let item = e.detail.item;
 
-    let res = await fetch(`/api/${collection}/${item.id}`, {
-      method: 'put',
-      body: JSON.stringify({
-        item,
-      }),
-    });
-    console.log('saved');
+    if (item.id) {
+      let res = await fetch(`/api/${collection}/${item.id}`, {
+        method: 'put',
+        body: JSON.stringify({
+          item,
+        }),
+      });
+      let json = await res.json();
+      console.log('saved', json);
+    }
+    else {
+      let res = await fetch(`/api/${collection}`, {
+        method: 'post',
+        body: JSON.stringify({
+          item,
+        }),
+      });
+      let json = await res.json();
+      console.log('created', json);
+
+      // 単体編集ページに遷移
+      goto(`/${collection}/${json.item.id}`, {
+        replaceState: true,
+      });
+    }
   };
 </script>
 
@@ -41,6 +68,6 @@
     Sidebar.w300.bg-royalblue.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        h1.mb16 {content.label} / {item.id}
+        h1.mb16 {content.label} / {item.id || 'new'}
         ContentForm(item='{item}', schemas='{content.schemas}', on:submit='{submit}')
 </template>

--- a/src/routes/[collection]/index.svelte
+++ b/src/routes/[collection]/index.svelte
@@ -33,9 +33,13 @@
     Sidebar.w300.bg-royalblue.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        div.f.fm.flex-between
-          h1.mb16 {content.label}
-          a.fs12(href='/{content.path}/edit') edit
+        div.f.fm.flex-between.mb16
+          div.f.fm
+            h1.mr8 {content.label}
+            a.fs12.p4.mt6(href='/{content.path}/edit')
+              i.material-icons.fs18 edit
+          div
+            a.button.primary(href='/{content.path}/new') NEW
 
         ContentList(items='{items}', headings='{content.headings}', on:select='{select}')
 </template>


### PR DESCRIPTION
## 対応内容

- 新規作成ボタンを配置
- POST API を作成
- 編集ページで新規作成(new)だったら POST して単体ページに遷移する

## 確認方法

- [ ] users の右上にある NEW をクリック
- [ ] 適当に入力して SAVE
- [ ] URL が新しいアイテムの id に変わっていたら OK

## リンク

- 確認URL ... https://svelte-admin-pr-7.herokuapp.com/users
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c95hoca23akg02hs1ipg)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/161590270-3409c0ed-3431-4085-b491-5aefd6fb954f.png)


