### PR TITLE
設定した値に応じて form の出し分けができるよう対応

### DIFF
--- a/src/demo/contents.json
+++ b/src/demo/contents.json
@@ -6,7 +6,10 @@
       {
         "type": "text",
         "label": "ID",
-        "key": "id"
+        "key": "id",
+        "opts": {
+          "readonly": true
+        }
       },
       {
         "key": "screen_name",

--- a/src/demo/curd.js
+++ b/src/demo/curd.js
@@ -22,6 +22,10 @@ export const create = (key) => {
   return async function({request, params, url}) {
     let item = generator();
     let body = await request.json();
+
+    // id は無視する
+    delete body.item.id;
+    
     Object.assign(item, body.item);
 
     items.unshift(item);

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -17,6 +17,15 @@
       item,
     });
   };
+
+  let getObjectSchema = () => {
+    return {
+      type: "object",
+      opts: {
+        schemas: schemas,
+      }
+    };
+  };
 </script>
 
 <template lang='pug'>
@@ -24,9 +33,6 @@
     form(on:submit|preventDefault='{submit}')
       div.f.fr
         button.button.primary.mb16 save
-      div.row.mxn8
-        +each('schemas as schema')
-          div.px8.mb16.w-full(class='{schema.class}')
-            //- svelte:component(this='{forms[schema.type]}', value='{ getByPath(item, schema.key) }')
-            svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{item[schema.key]}')
+      div
+        svelte:component(this='{forms.object}', schema='{getObjectSchema()}', bind:value='{item}')
 </template>

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -7,14 +7,14 @@
 
   let className;
   export {className as class};
-  export let item;
+  export let value;
   export let schemas;
 
   let dispatch = createEventDispatcher();
 
   let submit = () => {
     dispatch('submit', {
-      item,
+      value,
     });
   };
 
@@ -34,5 +34,5 @@
       div.f.fr
         button.button.primary.mb16 save
       div
-        svelte:component(this='{forms.object}', schema='{getObjectSchema()}', bind:value='{item}')
+        svelte:component(this='{forms.object}', schema='{getObjectSchema()}', bind:value='{value}')
 </template>

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -20,6 +20,22 @@
     }
     return opts;
   };
+
+  let isShow = (schema) => {
+    let condition = schema.condition;
+    if (condition) {
+      let a = value[condition.key];
+      let b = condition.value;
+
+      if (condition.operation === '==') {
+        return a === b;
+      }
+      // TODO: <, <=, >, >=
+
+      return false;
+    }
+    return true;
+  };
 </script>
 
 <template lang='pug'>
@@ -29,6 +45,7 @@
         div.fs12.mb4 {schema.label}
     div.row.p16.mxn8
       +each('getOpts().schemas as schema')
-        div.w-full.px8.mb16.mb0-last(class='{schema.class}')
-          svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{value[schema.key]}')
+        +if('isShow(schema, value)')
+          div.w-full.px8.mb16.mb0-last(class='{schema.class}')
+            svelte:component(this='{forms[schema.type]}', schema='{schema}', item='{value}', bind:value='{value[schema.key]}')
 </template>

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -21,7 +21,7 @@
     return opts;
   };
 
-  let isShow = (schema) => {
+  let shouldShow = (schema) => {
     let condition = schema.condition;
     if (condition) {
       let a = value[condition.key];
@@ -45,7 +45,7 @@
         div.fs12.mb4 {schema.label}
     div.row.p16.mxn8
       +each('getOpts().schemas as schema')
-        +if('isShow(schema, value)')
+        +if('shouldShow(schema, value)')
           div.w-full.px8.mb16.mb0-last(class='{schema.class}')
             svelte:component(this='{forms[schema.type]}', schema='{schema}', item='{value}', bind:value='{value[schema.key]}')
 </template>

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -44,7 +44,7 @@
       div.bg-aliceblue.border-bottom.p8
         div.fs12.mb4 {schema.label}
     div.row.p16.mxn8
-      +each('getOpts().schemas as schema')
+      +each('getOpts(schema).schemas as schema')
         +if('shouldShow(schema, value)')
           div.w-full.px8.mb16.mb0-last(class='{schema.class}')
             svelte:component(this='{forms[schema.type]}', schema='{schema}', item='{value}', bind:value='{value[schema.key]}')

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -10,6 +10,16 @@
   if (!value) {
     value = {};
   }
+
+  let getOpts = () => {
+    let opts = schema.opts;
+    if (typeof schema.opts === 'function') {
+      opts = schema.opts({
+        value,
+      });
+    }
+    return opts;
+  };
 </script>
 
 <template lang='pug'>
@@ -18,7 +28,7 @@
       div.bg-aliceblue.border-bottom.p8
         div.fs12.mb4 {schema.label}
     div.row.p16.mxn8
-      +each('schema.opts.schemas as schema')
+      +each('getOpts().schemas as schema')
         div.w-full.px8.mb16.mb0-last(class='{schema.class}')
           svelte:component(this='{forms[schema.type]}', schema='{schema}', bind:value='{value[schema.key]}')
 </template>

--- a/src/lib/forms/Text.svelte
+++ b/src/lib/forms/Text.svelte
@@ -9,5 +9,5 @@
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}')
+    input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}', readonly!='{schema.opts && schema.opts.readonly}')
 </template>

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -33,7 +33,7 @@
   export let content;
 
   let submit = async (e) => {
-    let item = e.detail.item;
+    let item = e.detail.value;
 
     if (item.id) {
       let res = await fetch(`/api/${collection}/${item.id}`, {
@@ -69,5 +69,5 @@
     main.w-full
       div.container-960.px16.py32
         h1.mb16 {content.label} / {item.id || 'new'}
-        ContentForm(item='{item}', schemas='{content.schemas}', on:submit='{submit}')
+        ContentForm(value='{item}', schemas='{content.schemas}', on:submit='{submit}')
 </template>

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -32,28 +32,32 @@
       "opts": {
         "schema": {
           "type": "object",
-          "opts": {
-            "schemas": [
-              {
-                "key": "key",
-                "label": "key",
-                "type": "text",
-                "class": "col4",
-              },
-              {
-                "key": "label",
-                "label": "label",
-                "type": "text",
-                "class": "col4",
-              },
-              {
-                "key": "type",
-                "label": "type",
-                "type": "text",
-                "class": "col4",
-              },
-            ]
-          }
+          "opts": ({value}) => {
+            let opts = {
+              "schemas": [
+                { "key": "key", "label": "key", "type": "text", "class": "col4", },
+                { "key": "label", "label": "label", "type": "text", "class": "col4", },
+                { "key": "type", "label": "type", "type": "text", "class": "col4", },
+              ]
+            };
+
+            if (value.type === 'number') {
+              opts.schemas.push({
+                "key": "opts",
+                "label": "opts",
+                "type": "object",
+                "opts": {
+                  "schemas": [
+                    { "key": "min", "label": "min", "type": "number", "class": "col4", },
+                    { "key": "max", "label": "max", "type": "number", "class": "col4", },
+                    { "key": "step", "label": "step", "type": "number", "class": "col4", },
+                  ]
+                }
+              });
+            }
+
+            return opts;
+          },
         }
       }
     },

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -16,6 +16,7 @@
   import { ContentForm, Sidebar } from "svelte-admin-components";
 
   export let content;
+  export let collection;
 
   let schemas = [
     {
@@ -80,8 +81,11 @@
   ];
 
   let submit = async (e) => {
-    let item = e.detail.item;
+    let value = e.detail.value;
 
+    // 更新
+    admin.contents[collection] = value;
+    
     await fetch('/api/contents', {
       method: 'post',
       body: JSON.stringify({
@@ -99,5 +103,5 @@
     main.w-full
       div.container-960.px16.py32
         h1.mb16 {content.label} edit
-        ContentForm(item='{content}', schemas='{schemas}', on:submit='{submit}')
+        ContentForm(value='{content}', schemas='{schemas}', on:submit='{submit}')
 </template>

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -70,7 +70,8 @@
                     { "key": "step", "label": "step", "type": "number", "class": "col4", },
                   ]
                 }
-              }
+              },
+              // TODO: 他の type 用のも作っていく
             ],
           },
         }

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -32,20 +32,37 @@
       "opts": {
         "schema": {
           "type": "object",
-          "opts": ({value}) => {
-            let opts = {
-              "schemas": [
-                { "key": "key", "label": "key", "type": "text", "class": "col4", },
-                { "key": "label", "label": "label", "type": "text", "class": "col4", },
-                { "key": "type", "label": "type", "type": "text", "class": "col4", },
-              ]
-            };
-
-            if (value.type === 'number') {
-              opts.schemas.push({
+          "opts": {
+            "schemas": [
+              { "key": "key", "label": "key", "type": "text", "class": "col4", },
+              { "key": "label", "label": "label", "type": "text", "class": "col4", },
+              { "key": "type", "label": "type", "type": "text", "class": "col4", },
+              // for textarea
+              {
                 "key": "opts",
                 "label": "opts",
                 "type": "object",
+                "condition": {
+                  "key": 'type',
+                  "operation": "==",
+                  "value": 'textarea',
+                },
+                "opts": {
+                  "schemas": [
+                    { "key": "cols", "label": "cols", "type": "number", "class": "col4", },
+                  ]
+                }
+              },
+              // for number
+              {
+                "key": "opts",
+                "label": "opts",
+                "type": "object",
+                "condition": {
+                  "key": 'type',
+                  "operation": "==",
+                  "value": 'number',
+                },
                 "opts": {
                   "schemas": [
                     { "key": "min", "label": "min", "type": "number", "class": "col4", },
@@ -53,10 +70,8 @@
                     { "key": "step", "label": "step", "type": "number", "class": "col4", },
                   ]
                 }
-              });
-            }
-
-            return opts;
+              }
+            ],
           },
         }
       }


### PR DESCRIPTION
## 対応内容

- [opts を関数で指定できるよう対応](https://github.com/rabee-inc/svelte-admin-components/pull/12/commits/6a61ded583b5b4ee99b2afe7235a90e08cd04d3a)(結局これは使ってない)
- [condition によってフォームの出し分けができるよう対応](https://github.com/rabee-inc/svelte-admin-components/pull/12/commits/fc741403388beab7dc4a5550f28ce4ea4b088f62)

## 確認方法

- [ ] https://svelte-admin-pr-12.herokuapp.com/users/edit にアクセス
- [ ] type に number を指定したら新たに opts form が出れば OK

## リンク

- 確認URL ... https://svelte-admin-pr-12.herokuapp.com/users/edit
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c96rc8q23akg02gqbr6g)

## スクショ

https://www.awesomescreenshot.com/video/8270076?key=e53c3b78ccf6f0285f7912097ebe7398