### PR TITLE
Image form を作成

### DIFF
--- a/src/demo/admin.js
+++ b/src/demo/admin.js
@@ -19,6 +19,17 @@ const admin = {
     },
   ],
   contents,
+  actions: {
+    // selectImage() {
+    //   // 画像選択モーダル開いたり
+    // },
+    uploadImage(file) {
+      let url = URL.createObjectURL(file);
+      return {
+        url,
+      };
+    },
+  }
 };
 
 export default admin;

--- a/src/demo/contents.json
+++ b/src/demo/contents.json
@@ -132,6 +132,11 @@
             }
           ]
         }
+      },
+      {
+        "type": "image",
+        "label": "アイキャッチ",
+        "key": "image"
       }
     ],
     "headings": [

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -9,6 +9,7 @@
   export {className as class};
   export let value;
   export let schemas;
+  export let actions;
 
   let dispatch = createEventDispatcher();
 
@@ -34,5 +35,5 @@
       div.f.fr
         button.button.primary.mb16 save
       div
-        svelte:component(this='{forms.object}', schema='{getObjectSchema()}', bind:value='{value}', border='{false}')
+        svelte:component(this='{forms.object}', schema='{getObjectSchema()}', actions='{actions}', bind:value='{value}', border='{false}')
 </template>

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -31,7 +31,7 @@
     if (/^image/.test(file.type) === false) return ;
 
     // アップロードしてセット
-    setImage();
+    setImage(file);
   };
 
   let setImage = (file) => {

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -30,10 +30,7 @@
     // 画像以外は弾く
     if (/^image/.test(file.type) === false) return ;
 
-    setImage(file);
-  };
-
-  let setImage = (file) => {
+    // アップロードしてセット
     let image = actions.uploadImage(file);
     value = image;
   };

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -1,3 +1,5 @@
+
+
 <svelte:options accessors={true}/>
 
 <script>
@@ -9,7 +11,7 @@
 
   let input;
 
-  // 画像を click
+  // 画像を click したとき
   let click = async () => {
     if (actions.selectImage) {
       let image = await actions.selectImage();
@@ -56,7 +58,10 @@
     +if('schema.label')
       div.fs12.mb4 {schema.label}
     div.relative.inline-block(on:dragover|preventDefault!='{() => {}}', on:drop|preventDefault='{drop}')
-      img.max-height-300(src='{value.url}')
+      +if('value.url')
+        img.max-height-300(src='{!value || value.url}')
+        +else
+          div.w200.square.bg-whitesmoke
       div.absolute.trbl0.s-full.f.fh.fs26.cursor-pointer(on:click='{click}') +
     //- input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}', readonly!='{schema.opts?.readonly}')
 </template>

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -31,6 +31,10 @@
     if (/^image/.test(file.type) === false) return ;
 
     // アップロードしてセット
+    setImage();
+  };
+
+  let setImage = (file) => {
     let image = actions.uploadImage(file);
     value = image;
   };

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -1,1 +1,56 @@
-<div>Todo Image</div>
+<svelte:options accessors={true}/>
+
+<script>
+  import { onMount } from "svelte";
+
+  export let schema;
+  export let actions;
+  export let value = '';
+
+  let input;
+  let click = async () => {
+    if (actions.selectImage) {
+      let image = await actions.selectImage();
+      value = image;
+    }
+    else {
+      input.click();
+    }
+  };
+
+  let setImage = (file) => {
+    let image = actions.uploadImage(file);
+    value = image;
+  };
+
+  onMount(() => {
+    input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+
+    input.onchange = (e) => {
+      let file = e.target.files[0];
+      if (!file) return ;
+
+      setImage(file);
+    };
+  });
+
+</script>
+
+<template lang='pug'>
+  label.block
+    +if('schema.label')
+      div.fs12.mb4 {schema.label}
+    div.relative.inline-block
+      img.max-height-300(src='{value.url}')
+      div.absolute.trbl0.s-full.f.fh.fs26.cursor-pointer(on:click='{click}') +
+    //- input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}', readonly!='{schema.opts?.readonly}')
+</template>
+
+
+<style lang="less">
+  .max-height-300 {
+    max-height: 300px;
+  }
+</style>

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -8,6 +8,8 @@
   export let value = '';
 
   let input;
+
+  // 画像を click
   let click = async () => {
     if (actions.selectImage) {
       let image = await actions.selectImage();
@@ -16,6 +18,17 @@
     else {
       input.click();
     }
+  };
+
+  // 画像を drop したとき
+  let drop = (e) => {
+    var file = e.dataTransfer.files[0];
+    if (!file) return ;
+
+    // 画像以外は弾く
+    if (/^image/.test(file.type) === false) return ;
+
+    setImage(file);
   };
 
   let setImage = (file) => {
@@ -42,7 +55,7 @@
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    div.relative.inline-block
+    div.relative.inline-block(on:dragover|preventDefault!='{() => {}}', on:drop|preventDefault='{drop}')
       img.max-height-300(src='{value.url}')
       div.absolute.trbl0.s-full.f.fh.fs26.cursor-pointer(on:click='{click}') +
     //- input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}', readonly!='{schema.opts?.readonly}')

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -4,6 +4,7 @@
   import { forms } from "$lib/index.js";
 
   export let schema;
+  export let actions;
   export let value;
   export let border = true;
 
@@ -48,5 +49,5 @@
       +each('getOpts(schema).schemas as schema')
         +if('shouldShow(schema, value)')
           div.w-full.px8.mb16(class='{schema.class}')
-            svelte:component(this='{forms[schema.type]}', schema='{schema}', item='{value}', bind:value='{value[schema.key]}')
+            svelte:component(this='{forms[schema.type]}', schema='{schema}', actions='{actions}', item='{value}', bind:value='{value[schema.key]}')
 </template>

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -69,5 +69,5 @@
     main.w-full
       div.container-960.px16.py32
         h1.mb16 {content.label} / {item.id || 'new'}
-        ContentForm(value='{item}', schemas='{content.schemas}', on:submit='{submit}')
+        ContentForm(value='{item}', schemas='{content.schemas}', actions='{admin.actions}', on:submit='{submit}')
 </template>

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -103,5 +103,5 @@
     main.w-full
       div.container-960.px16.py32
         h1.mb16 {content.label} edit
-        ContentForm(value='{content}', schemas='{schemas}', on:submit='{submit}')
+        ContentForm(value='{content}', schemas='{schemas}', actions='{admin.actions}', on:submit='{submit}')
 </template>


### PR DESCRIPTION
## 対応内容

- Image form を作成
- [actions を渡せるよう対応](https://github.com/rabee-inc/svelte-admin-components/pull/15/commits/19727e826de0d36f1dc8b0874eebdd1d70cadac6)
- [drag & drop 対応](https://github.com/rabee-inc/svelte-admin-components/pull/15/commits/25304c4c70f428739f1fb0da190b558a0a424ab6)

## 確認方法

- [ ] https://svelte-admin-pr-15.herokuapp.com/posts/3ffda9e0-6bee-4482-9c1f-c0e115c80bff にアクセス
- [ ] 画像のとこをクリック
- [ ] 画像を選択して保存
- [ ] 反映されてれば OK
- [ ] Drag & Drop も試してね　

## リンク

- 確認URL ... https://svelte-admin-pr-15.herokuapp.com/posts/3ffda9e0-6bee-4482-9c1f-c0e115c80bff
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c984jia23akg02hbsq10)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/162462353-dbb88b4a-8de1-4834-b356-962d9ee28b47.png)

