### PR TITLE
削除対応

### DIFF
--- a/src/demo/curd.js
+++ b/src/demo/curd.js
@@ -92,7 +92,29 @@ export const update = (key) => {
 
 // 
 export const del = (key) => {
+  let items = dummy[key];
 
+  return async function({request, params, url}) {
+
+    let index = items.findIndex(item => item['id'] === params['id']);
+
+    if (index === -1) {
+      return {
+        status: '404',
+        body: {
+          message: `Not found: ${params['id']}`,
+        }
+      }
+    }
+
+    items.splice(index, 1);
+
+    return {
+      body: {
+        message: `deleted ${params['id']}`,
+      }
+    };
+  }
 };
 
 // 

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -21,6 +21,13 @@
     });
   };
 
+  let del = async () => {
+    let value = await instance.getValue();
+    dispatch('delete', {
+      value,
+    });
+  };
+
   let getObjectSchema = () => {
     return {
       type: "object",
@@ -29,13 +36,15 @@
       }
     };
   };
+
 </script>
 
 <template lang='pug'>
   div(class='{className}')
     form(on:submit|preventDefault='{submit}')
-      div.f.fr
-        button.button.primary.mb16 save
+      div.f.fr.mb16
+        button.button.danger.mr8(type='button', on:click!='{del}') delete
+        button.button.primary save
       div
         svelte:component(bind:this='{instance}', this='{forms.object}', schema='{getObjectSchema()}', actions='{actions}', value='{value}', border='{false}')
 </template>

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -12,16 +12,20 @@
   export let actions;
 
   let dispatch = createEventDispatcher();
+  let form;
   let instance;
 
-  let submit = async () => {
+  export let submit = async () => {
+    // check validity
+    if (!form.reportValidity()) return ;
+
     let value = await instance.getValue();
     dispatch('submit', {
       value,
     });
   };
 
-  let del = async () => {
+  export let del = async () => {
     let value = await instance.getValue();
     dispatch('delete', {
       value,
@@ -41,10 +45,9 @@
 
 <template lang='pug'>
   div(class='{className}')
-    form(on:submit|preventDefault='{submit}')
-      div.f.fr.mb16
-        button.button.danger.mr8(type='button', on:click!='{del}') delete
-        button.button.primary save
+    form(bind:this='{form}', on:submit|preventDefault='{submit}')
+      //- Enter 用に submit ボタンを配置
+      button.hide(type='submit')
       div
         svelte:component(bind:this='{instance}', this='{forms.object}', schema='{getObjectSchema()}', actions='{actions}', value='{value}', border='{false}')
 </template>

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -32,6 +32,8 @@
   export let item;
   export let content;
 
+  let form;
+
   let submit = async (e) => {
     let item = e.detail.value;
 
@@ -62,12 +64,11 @@
     }
   };
 
-  let del = async (e) => {
+  let del = async () => {
     if (!confirm('really?')) {
       return ;
     }
-    
-    let item = e.detail.value;
+
     await fetch(`/api/${collection}/${item.id}`, {
       method: 'delete',
     });
@@ -86,6 +87,11 @@
     Sidebar.w300.bg-primary.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        h1.mb16 {content.label} / {item.id || 'new'}
-        ContentForm(value='{item}', schemas='{content.schemas}', actions='{admin.actions}', on:submit='{submit}', on:delete='{del}')
+        div.f.fm.flex-between
+          h1.fs16.mb16 {content.label} / {item.id || 'new'}
+          div.f.fr
+            +if('item.id')
+              button.button.danger.mr8(type='button', on:click!='{del}') delete
+            button.button.primary(on:click='{form.submit()}') {item.id ? 'save' : 'create'}
+        ContentForm(bind:this='{form}', value='{item}', schemas='{content.schemas}', actions='{admin.actions}', on:submit='{submit}', on:delete='{del}')
 </template>

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -87,9 +87,9 @@
     Sidebar.w300.bg-primary.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        div.f.fm.flex-between
-          h1.fs16.mb16 {content.label} / {item.id || 'new'}
-          div.f.fr
+        div.f.fm.flex-between.mb16
+          h1.fs16 {content.label} / {item.id || 'new'}
+          div.f
             +if('item.id')
               button.button.danger.mr8(type='button', on:click!='{del}') delete
             button.button.primary(on:click='{form.submit()}') {item.id ? 'save' : 'create'}

--- a/src/routes/[collection]/[id].svelte
+++ b/src/routes/[collection]/[id].svelte
@@ -61,6 +61,24 @@
       });
     }
   };
+
+  let del = async (e) => {
+    if (!confirm('really?')) {
+      return ;
+    }
+    
+    let item = e.detail.value;
+    await fetch(`/api/${collection}/${item.id}`, {
+      method: 'delete',
+    });
+
+    console.log('deleted');
+
+    // 一覧ページに戻る
+    goto(`/${collection}`, {
+      replaceState: true,
+    });
+  };
 </script>
 
 <template lang='pug'>
@@ -69,5 +87,5 @@
     main.w-full
       div.container-960.px16.py32
         h1.mb16 {content.label} / {item.id || 'new'}
-        ContentForm(value='{item}', schemas='{content.schemas}', actions='{admin.actions}', on:submit='{submit}')
+        ContentForm(value='{item}', schemas='{content.schemas}', actions='{admin.actions}', on:submit='{submit}', on:delete='{del}')
 </template>

--- a/src/routes/[collection]/edit.svelte
+++ b/src/routes/[collection]/edit.svelte
@@ -18,6 +18,8 @@
   export let content;
   export let collection;
 
+  let form;
+
   let submit = async (e) => {
     let value = e.detail.value;
 
@@ -41,6 +43,9 @@
     Sidebar.w300.bg-primary.text-white(sections='{admin.sections}')
     main.w-full
       div.container-960.px16.py32
-        h1.mb16 {content.label} edit
-        ContentForm(value='{content}', schemas='{CONTENT_SCHEMA}', actions='{admin.actions}', on:submit='{submit}')
+        div.f.fm.flex-between.mb16
+          h1.fs16 {content.label} edit
+          div.f
+            button.button.primary(on:click='{form.submit()}') save
+        ContentForm(bind:this='{form}', value='{content}', schemas='{CONTENT_SCHEMA}', actions='{admin.actions}', on:submit='{submit}')
 </template>


### PR DESCRIPTION
## 対応内容

- [delete api を作成](https://github.com/rabee-inc/svelte-admin-components/pull/18/commits/ac73dda4b38d7f396c64735e42ea17355e435c01)
- 削除ボタンを配置
- save / delete を ContentForm から外出し(分岐とか見た目とかサービスによって変えると思うので)

## 確認方法

- [ ] 適当なアイテムを選択
- [ ] delete ボタンをクリック
- [ ] アイテムが消えれば OK

## リンク

- 確認URL ... https://svelte-admin-pr-18.herokuapp.com/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c99srra23akg02k0rsog)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/162679884-fbde01fa-12b4-461f-ab4f-5600538a4023.png)


