### PR TITLE
スキーマ編集時の opts で required と readonly を設定できるよう対応

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -6,17 +6,24 @@
       {
         "key": "id",
         "label": "ID",
-        "type": "text"
+        "type": "text",
+        "opts": {
+          "readonly": true
+        }
       },
       {
         "key": "screen_name",
         "label": "名前",
-        "type": "text"
+        "type": "text",
+        "opts": {
+          "required": true
+        }
       },
       {
         "key": "display_name",
         "label": "表示名",
-        "type": "text"
+        "type": "text",
+        "opts": {}
       },
       {
         "key": "bio",

--- a/src/lib/forms/Text.svelte
+++ b/src/lib/forms/Text.svelte
@@ -9,5 +9,5 @@
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts && schema.opts.required}', readonly!='{schema.opts?.readonly}', on:change)
+    input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -9,5 +9,5 @@
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    textarea.w-full.border.px8.py4(bind:value, rows='8', on:change)
+    textarea.w-full.border.px8.py4(bind:value, rows='8', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -10,6 +10,13 @@ export { default as contents } from './contents/index.js';
 export { default as forms } from './forms/index.js';
 import forms from './forms/index.js';
 
+const SCHEMA_REQUIRED = {
+  "key": "opts.required", "label": "required", "type": "switch", "class": "col2",
+};
+const SCHEMA_READONLY = {
+  "key": "opts.readonly", "label": "readonly", "type": "switch", "class": "col2",
+};
+
 // edit 用 shcema
 export const FORM_SCHEMA = [
   {
@@ -26,6 +33,22 @@ export const FORM_SCHEMA = [
       }),
     },
   },
+  // for text
+  {
+    "key": "opts",
+    "label": "opts",
+    "type": "object",
+    "condition": {
+      "key": 'type',
+      "operation": "==",
+      "value": 'text',
+    },
+    "opts": {
+      "schemas": [
+        SCHEMA_REQUIRED, SCHEMA_READONLY,
+      ]
+    }
+  },
   // for textarea
   {
     "key": "opts",
@@ -38,6 +61,7 @@ export const FORM_SCHEMA = [
     },
     "opts": {
       "schemas": [
+        SCHEMA_REQUIRED, SCHEMA_READONLY,
         { "key": "cols", "label": "cols", "type": "number", "class": "col4", },
       ]
     }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -11,10 +11,10 @@ export { default as forms } from './forms/index.js';
 import forms from './forms/index.js';
 
 const SCHEMA_REQUIRED = {
-  "key": "opts.required", "label": "required", "type": "switch", "class": "col2",
+  "key": "required", "label": "required", "type": "switch", "class": "col2",
 };
 const SCHEMA_READONLY = {
-  "key": "opts.readonly", "label": "readonly", "type": "switch", "class": "col2",
+  "key": "readonly", "label": "readonly", "type": "switch", "class": "col2",
 };
 
 // edit 用 shcema


### PR DESCRIPTION
## 対応内容

- SSIA
- Text と Textarea のみとりあえず対応
- 見た目の調整は別タスク

## 確認方法

- [ ] ユーザー編集ページの ID が編集不可になってれば OK
- [ ] ユーザー編集ページで名前が必須になってれば OK

## リンク

- 確認URL ... https://svelte-admin-pr-20.herokuapp.com/users/9bd9d8d6-9a67-44e0-b467-cc8796ed151a
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c99ssvi23akg02k0ru8g)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/162688951-f4dc96ba-76e3-41c2-834b-4235b9f1b6c0.png)


