### PR TITLE
readonly, required の見た目対応

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -23,14 +23,16 @@
         "key": "display_name",
         "label": "表示名",
         "type": "text",
-        "opts": {}
+        "opts": {
+          "required": false
+        }
       },
       {
         "key": "bio",
         "label": "プロフィール",
         "type": "textarea",
         "opts": {
-          "cols": ""
+          "cols": 20
         }
       },
       {

--- a/src/admin/dummy.js
+++ b/src/admin/dummy.js
@@ -11,7 +11,9 @@ export function image() {
 };
 
 export function user() {
+  const GENDERS = ['male', 'female', 'other'];
   let name = faker.name.firstName();
+  
   return {
     id: faker.datatype.uuid(),
     // id: '1',
@@ -23,6 +25,7 @@ export function user() {
     following_count: faker.datatype.number() % 1000,
     created_at: faker.datatype.datetime().getTime(),
     age: faker.datatype.number({min: 18, max: 64}),
+    gender: GENDERS[faker.datatype.number() % 3],
   };
 };
 

--- a/src/lib/forms/Number.svelte
+++ b/src/lib/forms/Number.svelte
@@ -8,6 +8,8 @@
 <template lang='pug'>
   label.block
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    input.input.w-full(bind:value, type='number', on:change)
+      div.fs12.mb4 {schema.label} 
+        +if('schema.opts?.required')
+          span *
+    input.input.w-full(bind:value, type='number', , required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Number.svelte
+++ b/src/lib/forms/Number.svelte
@@ -11,5 +11,5 @@
       div.fs12.mb4 {schema.label} 
         +if('schema.opts?.required')
           span *
-    input.input.w-full(bind:value, type='number', , required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
+    input.input.w-full(bind:value, type='number', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Select.svelte
+++ b/src/lib/forms/Select.svelte
@@ -8,8 +8,11 @@
 <template lang='pug'>
   label.block
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    select.px8.py4.border.rounded-4.lh15(bind:value, on:change)
+      div.fs12.mb4 {schema.label} 
+        +if('schema.opts?.required')
+          span *
+    //- TODO: select は readonly 効かないので対策考える
+    select.px8.py4.border.rounded-4.lh15(bind:value, required!='{schema.opts?.required}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
       +each('schema.opts.choices as choice')
         option(value='{choice.value}') {choice.label || choice.value}
 </template>

--- a/src/lib/forms/Text.svelte
+++ b/src/lib/forms/Text.svelte
@@ -8,6 +8,8 @@
 <template lang='pug'>
   label.block
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    input.w-full.border.px8.py4(type='text', bind:value='{value}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', on:change)
+      div.fs12.mb4 {schema.label} 
+        +if('schema.opts?.required')
+          span *
+    input.w-full.border.rounded-4.px8.py4(type='text', bind:value='{value}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Text.svelte
+++ b/src/lib/forms/Text.svelte
@@ -11,5 +11,5 @@
       div.fs12.mb4 {schema.label} 
         +if('schema.opts?.required')
           span *
-    input.w-full.border.rounded-4.px8.py4(type='text', bind:value='{value}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
+    input.w-full.border.rounded-4.px8.py4(bind:value, type='text', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -8,6 +8,8 @@
 <template lang='pug'>
   label.block
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
-    textarea.w-full.border.px8.py4(bind:value, rows='8', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', on:change)
+      div.fs12.mb4 {schema.label} 
+        +if('schema.opts?.required')
+          span *
+    textarea.w-full.border.rounded-4.px8.py4(bind:value, rows='{schema.opts?.cols || 8}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -78,6 +78,7 @@ export const FORM_SCHEMA = [
     },
     "opts": {
       "schemas": [
+        SCHEMA_REQUIRED, SCHEMA_READONLY,
         { "key": "min", "label": "min", "type": "number", "class": "col4", },
         { "key": "max", "label": "max", "type": "number", "class": "col4", },
         { "key": "step", "label": "step", "type": "number", "class": "col4", },

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -97,6 +97,7 @@ export const FORM_SCHEMA = [
     },
     "opts": {
       "schemas": [
+        SCHEMA_REQUIRED, SCHEMA_READONLY,
         {
           "key": "choices",
           "label": "choices",


### PR DESCRIPTION
## 対応内容

- readonly が true だったら背景をグレーに
- required が true だったら * を表示

## 確認方法

- [ ] ユーザー編集ページで, id がグレーに, 名前に * が表示されてれば OK

## リンク

- 確認URL ... https://svelte-admin-pr-21.herokuapp.com/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c9catkq23akg02mc9cug)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/163493176-573a7f5c-4edc-423c-9a29-a6b932fde418.png)
