### PR TITLE
Date form に date_type を指定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ result
 ## License
 
 MIT
+

--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -213,14 +213,6 @@
           "is_section": true,
           "schemas": [
             {
-              "key": "date_default",
-              "label": "date(default)",
-              "type": "date",
-              "opts": {
-                "is_unixtime": true
-              }
-            },
-            {
               "key": "date_datetime",
               "label": "datetime",
               "type": "date",
@@ -250,6 +242,15 @@
               "type": "date",
               "opts": {
                 "date_type": "week"
+              }
+            },
+            {
+              "key": "date_unixtime",
+              "label": "date(unixtime)",
+              "type": "date",
+              "opts": {
+                "is_unixtime": true,
+                "date_type": "datetime"
               }
             }
           ]

--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -203,6 +203,56 @@
             }
           ]
         }
+      },
+      {
+        "key": "date_test",
+        "label": "日付のテスト",
+        "type": "object",
+        "opts": {
+          "is_section": true,
+          "schemas": [
+            {
+              "key": "date_default",
+              "label": "date(default)",
+              "type": "date",
+              "opts": {
+                "is_unixtime": true
+              }
+            },
+            {
+              "key": "date_datetime",
+              "label": "datetime",
+              "type": "date",
+              "opts": {
+                "date_type": "datetime"
+              }
+            },
+            {
+              "key": "date_date",
+              "label": "date",
+              "type": "date",
+              "opts": {
+                "date_type": "date"
+              }
+            },
+            {
+              "key": "date_month",
+              "label": "month",
+              "type": "date",
+              "opts": {
+                "date_type": "month"
+              }
+            },
+            {
+              "key": "date_week",
+              "label": "week",
+              "type": "date",
+              "opts": {
+                "date_type": "week"
+              }
+            }
+          ]
+        }
       }
     ],
     "headings": [

--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -48,7 +48,8 @@
       {
         "key": "created_at",
         "label": "作成日",
-        "type": "date"
+        "type": "date",
+        "opts": {}
       },
       {
         "key": "is_ambassador",

--- a/src/lib/forms/Date.svelte
+++ b/src/lib/forms/Date.svelte
@@ -6,14 +6,18 @@
   export let schema;
   export let value = '';
 
-  if (schema.opts.is_unixtime) {
-    // value = dayjs(value*1000).format('YYYY-MM-DDTHH:mm:ss');
-    value = dayjs(value).format('YYYY-MM-DDTHH:mm:ss');
+  let _value = '';
+
+  if (schema.opts.is_unixtime && value) {
+    _value = dayjs(value || undefined).format('YYYY-MM-DDTHH:mm');
+  }
+  else {
+    _value = value;
   }
 
   let input;
   let getType = () => {
-    let date_type = schema.opts.date_type;
+    let date_type = schema.opts.date_type || 'datetime-local';
     if (date_type === 'datetime') date_type += '-local';
 
     return date_type;
@@ -30,11 +34,12 @@
 
     return v;
   };
+
 </script>
 
 <template lang="pug">
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.input.w-full(bind:this='{input}', value='{value}', type='{getType()}', on:change)
+    input.input.w-full(bind:this='{input}', value='{_value}', type='{getType()}', on:change)
 </template>

--- a/src/lib/forms/Date.svelte
+++ b/src/lib/forms/Date.svelte
@@ -1,13 +1,40 @@
 <svelte:options accessors={true}/>
 
 <script>
+  import dayjs from 'dayjs';
+
   export let schema;
   export let value = '';
+
+  if (schema.opts.is_unixtime) {
+    // value = dayjs(value*1000).format('YYYY-MM-DDTHH:mm:ss');
+    value = dayjs(value).format('YYYY-MM-DDTHH:mm:ss');
+  }
+
+  let input;
+  let getType = () => {
+    let date_type = schema.opts.date_type;
+    if (date_type === 'datetime') date_type += '-local';
+
+    return date_type;
+  };
+
+  // svelte-ignore unused-export-let
+  export let getValue = () => {
+    let v = input.value;
+
+    if (schema.opts.is_unixtime) {
+      // return dayjs(v).unix();
+      return dayjs(v).valueOf();
+    }
+
+    return v;
+  };
 </script>
 
 <template lang="pug">
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.input.w-full(bind:value, type='date', on:change)
+    input.input.w-full(bind:this='{input}', value='{value}', type='{getType()}', on:change)
 </template>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -202,6 +202,34 @@ export const SCHEMA_FORM = [
       ]
     }
   },
+  // for date
+  {
+    "key": "opts",
+    "label": "opts",
+    "type": "object",
+    "condition": {
+      "key": 'type',
+      "operation": "==",
+      "value": 'date',
+    },
+    "opts": {
+      "schemas": [
+        // { "key": "format", "label": "format", "type": "text", "class": "col4", },
+        { "key": "is_unixtime", "label": "unixtime", "type": "switch", "class": "col4", },
+        {
+          "key": "date_type", "label": "type", "type": "select", "class": "col4",
+          "opts": {
+            "choices": [
+              { value: 'datetime', },
+              { value: 'date', },
+              { value: 'month', },
+              { value: 'week', },
+            ],
+          },
+        },      
+      ]
+    }
+  },
 
   // TODO: 他の type 用のも作っていく
 ];


### PR DESCRIPTION
## 対応内容

- Date form のオプションに date_type を追加
  - datetime, date, month, week を指定可能
- Date form のオプションに is_unixtime を追加
  - is_unixtime だったら 代入時、保存時に dayjs を噛ます

## 確認方法

- [ ] https://deploy-preview-30--svelte-admin-components.netlify.app/posts/66324ccb-06c8-4ca1-ad02-529270b8d572 にアクセス
- [ ] 日付がそれぞれ入力、保存されれば OK

## リンク

- 確認URL ... https://deploy-preview-30--svelte-admin-components.netlify.app/posts/66324ccb-06c8-4ca1-ad02-529270b8d572
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/c9scpdi23akg032gif70)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/167368407-da86bbcf-e318-4975-82db-d279d56372d1.png)
