### PR TITLE
外からフォームの種類を登録したり上書きしたりできるよう対応

### DIFF
--- a/src/lib/forms/index.js
+++ b/src/lib/forms/index.js
@@ -12,7 +12,7 @@ import Object from './Object.svelte';
 import Button from './Button.svelte';
 import Content from './Content.svelte';
 
-export default {
+let forms = {
   text: Text,
   textarea: Textarea,
   number: Number,
@@ -24,4 +24,10 @@ export default {
   object: Object,
   button: Button,
   content: Content,
+};
+
+export default forms;
+
+export let registerForm = (key, form) => {
+  forms[key] = form;
 };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,7 +8,7 @@ export { default as contents } from './contents/index.js';
 import contents from './contents/index.js';
 
 // forms
-export { default as forms } from './forms/index.js';
+export { default as forms, registerForm } from './forms/index.js';
 import forms from './forms/index.js';
 
 const SCHEMA_REQUIRED = {


### PR DESCRIPTION
SSIA

例) 既存の text を上書きする
```

  import Text from '$admin/Text.svelte';
  registerForm('text', Text);

```