### PR TITLE
section ごとに shouldShow メソッドで表示/非表示を切り替えられるよう対応

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -186,6 +186,11 @@
                 "type": "text"
               }
             }
+          },
+          {
+            "key": "meta",
+            "label": "is_meta",
+            "type": "switch"
           }
         ]
       },

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -55,7 +55,14 @@ const admin = {
         alert('view preview');
       },
     },
-  }
+  },
+};
+
+
+
+// DEBUG: メタの値に応じて分岐テスト
+admin.contents.posts.sections.find(s => s.label === 'メタ').shouldShow = ({section, value}) => {
+  return value.meta;
 };
 
 export default admin;

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -87,7 +87,7 @@
     // 更新したら sections の表示を再チェックする
     sections = sections;
 
-    console.log('changed');
+    dispatch('change');
   };
 
 </script>

--- a/src/lib/forms/Array.svelte
+++ b/src/lib/forms/Array.svelte
@@ -76,7 +76,7 @@
             div.relative.f.fm.p16.border-bottom.hover-trigger(data-id='{i}')
               img.handle.flex-fixed.p8.mr8(src='{handle}', alt='handle')
               div.w-full
-                svelte:component(bind:this='{instances[i]}', this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{v}')
+                svelte:component(bind:this='{instances[i]}', this='{forms[schema.opts.schema.type]}', schema='{schema.opts.schema}', bind:value='{v}', on:change)
               button.absolute.t8.r8.f.fh.s24.circle.border.bg-white.hover-show(type='button', on:click!='{() => {del(i)}}') ✕
       div.p16
         button.button.w-full(type='button', on:click='{add}') +

--- a/src/lib/forms/Image.svelte
+++ b/src/lib/forms/Image.svelte
@@ -3,7 +3,7 @@
 <svelte:options accessors={true}/>
 
 <script>
-  import { onMount } from "svelte";
+  import { createEventDispatcher, onMount } from "svelte";
 
   export let schema;
   export let actions;
@@ -19,6 +19,7 @@
 
   let input;
   let _file;
+  let dispatch = createEventDispatcher();
 
   // 画像を click したとき
   let click = async () => {
@@ -46,6 +47,8 @@
   let setImage = (file) => {
     value = URL.createObjectURL(file);
     _file = file;
+
+    dispatch('change');
   };
 
   onMount(() => {

--- a/src/lib/forms/Object.svelte
+++ b/src/lib/forms/Object.svelte
@@ -10,7 +10,10 @@
   export let value;
   export let item;
   export let frame = true;
-  
+
+  import { createEventDispatcher } from 'svelte';
+  let dispatch = createEventDispatcher();
+
   // svelte-ignore unused-export-let
   export let getValue = async () => {
     let v = {};
@@ -73,6 +76,8 @@
 
   let syncValue = async () => {
     value = await getValue();
+
+    dispatch('change');
   };
 
 </script>

--- a/src/routes/[content_id]/[id].svelte
+++ b/src/routes/[content_id]/[id].svelte
@@ -25,7 +25,6 @@
   }
 </script>
 <script>
-  import OriginalSection from "$admin/OriginalSection.svelte";
   import { goto } from "$app/navigation";
   import { ContentForm } from "svelte-admin-components";
   import { indicator } from 'svelte-modal-manager';
@@ -99,5 +98,5 @@
           button.button.danger.mr8(type='button', on:click!='{del}') delete
         button.button.primary(on:click='{form.submit()}') {item.id ? 'save' : 'create'}
     div.p16
-      ContentForm(bind:this='{form}', value='{item}', sections='{content.sections}', actions='{admin.actions}', on:submit='{submit}', on:delete='{del}', sectionComponent='{OriginalSection}')
+      ContentForm(bind:this='{form}', value='{item}', sections='{content.sections}', actions='{admin.actions}', on:submit='{submit}', on:delete='{del}')
 </template>


### PR DESCRIPTION
## 対応内容

- SSIA
- change イベントが発火していなかったものを発火するよう修正

## 確認方法

- [ ] post の is_meta の値に応じて meta section の表示/非表示が切り替われば OK
- [ ] 他デグレってなければ OK

## リンク

- 確認URL ... 
- [alog](#)
- [Figma](#)

## スクショ

https://www.awesomescreenshot.com/video/9395567?key=b1d5a1d5a302e60907a3815747351710

