### PR TITLE
Section コンポーネントに section を渡すよう対応(labelは削除)

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -130,6 +130,7 @@
       {
         "label": "メイン",
         "class": "col8",
+        "description": "メインとなる入力フォームです!",
         "schemas": [
           {
             "key": "id",

--- a/src/lib/components/ContentForm.svelte
+++ b/src/lib/components/ContentForm.svelte
@@ -115,6 +115,6 @@
           +each('sections as section,i')
             +if('shouldShowSection(section)')
               div.align-self-top.px8.mb16(class!='{section.class || ""}')
-                svelte:component(this='{sectionComponent}', label='{section.label}')
+                svelte:component(this='{sectionComponent}', section='{section}')
                   svelte:component(bind:this='{instances[i]}', this='{forms.object}', schema='{sectionToObjectSchema(section)}', actions='{actions}', value='{value}', formValue='{formValue}', frame='{false}', on:change='{onChange}')
 </template>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,12 +1,14 @@
 
 <script>
-  export let label;
+  export let section;
 </script>
 
 <template lang="pug">
   div.border.rounded-4
     div.bg-aliceblue.border-bottom.p8
-      div.fs12 {label}
+      div.fs12 {section.label}
     div.p16
+      +if('section.description')
+        p.text-darkgray.mb16 {section.description}
       slot
 </template>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -243,6 +243,15 @@ export const SCHEMA_SECTION = [
     "key": "class", "label": "class", "type": "text", "class": "col4",
   },
   {
+    "key": "description",
+    "label": "description",
+    "type": "textarea",
+    "class": "col12",
+    "opts": {
+      "cols": 2,
+    }
+  },
+  {
     "key": "schemas",
     "label": "schemas",
     "type": "array",


### PR DESCRIPTION
## 対応内容

- SSIA
- label は削除
- schema 編集に section.description を追加

## 確認方法

- [ ] [post 編集](https://deploy-preview-41--svelte-admin-components.netlify.app/posts/66324ccb-06c8-4ca1-ad02-529270b8d572) で section に description が出てれば OK

## リンク

- 確認URL ... https://deploy-preview-41--svelte-admin-components.netlify.app/posts/66324ccb-06c8-4ca1-ad02-529270b8d572
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cam40p223akg02k1svm0)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/174264978-02a7faab-b220-4438-a621-83409b927aa1.png)
