### PR TITLE
select の chices に関数/文字列を渡せるよう対応 && 一覧表示にマッピング情報を渡せるよう対応

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -84,6 +84,14 @@
             }
           },
           {
+            "key": "gender",
+            "label": "性別",
+            "type": "select",
+            "opts": {
+              "choices": "genders"
+            }
+          },
+          {
             "key": "is_ambassador",
             "label": "アンバサダー",
             "type": "switch"

--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -17,6 +17,14 @@
         "key": "screen_name",
         "label": "name",
         "type": "text"
+      },
+      {
+        "key": "gender",
+        "label": "gender",
+        "type": "text",
+        "opts": {
+          "mappings": "genders"
+        }
       }
     ],
     "sections": [

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -55,6 +55,14 @@ const admin = {
         alert('view preview');
       },
     },
+
+    genders() {
+      return [
+        { "value": "male", "label": "男性" },
+        { "value": "female", "label": "女性" },
+        { "value": "other", "label": "その他" }
+      ]
+    },
   },
 };
 

--- a/src/lib/components/ContentList.svelte
+++ b/src/lib/components/ContentList.svelte
@@ -9,6 +9,7 @@
   export {className as class};
   export let headings = [];
   export let items = [];
+  export let actions;
 
   let dispatch = createEventDispatcher();
 
@@ -32,7 +33,7 @@
           tr.border-bottom.transition.hover-bg.cursor-pointer(on:click!='{(e) => select(e, item)}')
             +each('headings as heading')
               td.p12.fs13
-                svelte:component(this='{contents[heading.type]}', value='{ getByPath(item, heading.key) }')
+                svelte:component(this='{contents[heading.type]}', value='{ getByPath(item, heading.key) }', heading='{heading}', actions='{actions}')
 </template>
 
 <style lang="less">

--- a/src/lib/contents/Date.svelte
+++ b/src/lib/contents/Date.svelte
@@ -2,6 +2,11 @@
 
 <script>
   import dayjs from 'dayjs';
+
+  // svelte-ignore unused-export-let
+  export let heading;
+  // svelte-ignore unused-export-let
+  export let actions;
   export let value = '';
 </script>
 

--- a/src/lib/contents/Image.svelte
+++ b/src/lib/contents/Image.svelte
@@ -1,6 +1,10 @@
 <svelte:options accessors={true}/>
 
 <script>
+  // svelte-ignore unused-export-let
+  export let heading;
+  // svelte-ignore unused-export-let
+  export let actions;
   export let value = '';
 </script>
 

--- a/src/lib/contents/Text.svelte
+++ b/src/lib/contents/Text.svelte
@@ -1,9 +1,47 @@
 <svelte:options accessors={true}/>
 
 <script>
+  import { onMount } from "svelte";
+
+  export let heading;
+  export let actions;
   export let value = '';
+
+  let _value = value;
+
+  onMount(() => {
+    _setup();
+  });
+
+  let _setup = async () => {
+    let mappings = heading.opts?.mappings;
+
+    if (mappings) {
+      if (typeof mappings === 'string') {
+        mappings = actions[mappings];
+
+        if (typeof mappings === 'function') {
+          mappings = await mappings();
+        }
+      }
+
+      if (Array.isArray(mappings)) {
+        // choices 形式だった場合
+        let hit = mappings.find(item => item.value === value);
+        _value = hit.label;
+      }
+      else {
+        // object だった場合
+        _value = mappings[value];
+      }
+    }
+    else {
+      _value = value;
+    }
+  };
+
 </script>
 
 <template lang='pug'>
-  p.line-clamp-3 {value}
+  p.line-clamp-3 {_value}
 </template>

--- a/src/lib/forms/Select.svelte
+++ b/src/lib/forms/Select.svelte
@@ -1,6 +1,8 @@
 <svelte:options accessors={true}/>
 
 <script>
+  import { onMount } from "svelte";
+
   export let schema;
   export let value = '';
   // svelte-ignore unused-export-let
@@ -10,6 +12,29 @@
   // svelte-ignore unused-export-let
   export let item;
 
+  let _choices = [];
+
+  let setupChoices = async (choices) => {
+    // 文字列だったら関数化して結果を返す
+    if (typeof choices === 'string') {
+      // 共通の関数もしくは配列に変換
+      choices = actions[choices];
+
+      if (typeof choices === 'function') {
+        _choices = await choices({schema, value});
+      }
+      else {
+        _choices = choices;
+      }
+    }
+    else {
+      _choices = choices;
+    }
+  };
+
+  onMount(() => {
+    setupChoices(schema.opts.choices);
+  });
 </script>
 
 <template lang='pug'>
@@ -20,6 +45,6 @@
           span *
     //- TODO: select は readonly 効かないので対策考える
     select.px8.py4.border.rounded-4.lh15(bind:value, required!='{schema.opts?.required}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
-      +each('schema.opts.choices as choice')
+      +each('_choices as choice')
         option(value='{choice.value}') {choice.label || choice.value}
 </template>

--- a/src/routes/[content_id]/index.svelte
+++ b/src/routes/[content_id]/index.svelte
@@ -50,5 +50,5 @@
       div
         a.button.primary(href='/{content.path}/new') NEW
     div.p16
-      ContentList(items='{items}', headings='{content.headings}', on:select='{select}')
+      ContentList(items='{items}', headings='{content.headings}', actions='{admin.actions}', on:select='{select}')
 </template>


### PR DESCRIPTION
## 対応内容

- SSIA

## 確認方法

- [ ] ユーザー一覧の gender が日本語になってれｂ OK
- [ ] ユーザー編集で gender 部分が１個目、２個目それぞれ同じ表示、選択肢が出てれば OK

## リンク

- 確認URL ... https://deploy-preview-44--svelte-admin-components.netlify.app/users
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/pXbBVncf5AIRRiQEYhoF/notes/cb33n5223akg02gvdoa0)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/178180238-7045015b-2a3e-452b-bc32-54f31fb41e26.png)


![image](https://user-images.githubusercontent.com/1156954/178180264-b6afbe5d-7086-44ea-a238-7413866040ce.png)
