### PR TITLE
date にも readonly と required 対応

### DIFF
--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -111,7 +111,8 @@
             "opts": {
               "is_unixtime": true,
               "date_type": "",
-              "readonly": true
+              "readonly": true,
+              "required": true
             }
           },
           {

--- a/src/admin/contents.json
+++ b/src/admin/contents.json
@@ -110,7 +110,8 @@
             "type": "date",
             "opts": {
               "is_unixtime": true,
-              "date_type": ""
+              "date_type": "",
+              "readonly": true
             }
           },
           {

--- a/src/lib/forms/Date.svelte
+++ b/src/lib/forms/Date.svelte
@@ -47,6 +47,8 @@
 <template lang="pug">
   label.block
     +if('schema.label')
-      div.fs12.mb4 {schema.label}
+      div.fs12.mb4 {schema.label} 
+        +if('schema.opts?.required')
+          span *
     input.input.w-full(bind:this='{input}', value='{_value}', type='{getType()}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>

--- a/src/lib/forms/Date.svelte
+++ b/src/lib/forms/Date.svelte
@@ -48,5 +48,5 @@
   label.block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.input.w-full(bind:this='{input}', value='{_value}', type='{getType()}', on:change)
+    input.input.w-full(bind:this='{input}', value='{_value}', type='{getType()}', required!='{schema.opts?.required}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>


### PR DESCRIPTION
## 対応内容

- SSIA

## 確認方法

- [ ] https://deploy-preview-53--svelte-admin-components.netlify.app/users/15be3e06-0807-4e2b-ae3a-b8845f0597a6 にアクセス
- [ ] 作成日が required && readonly になってれば OK

## リンク

- 確認URL ... https://deploy-preview-53--svelte-admin-components.netlify.app/users/15be3e06-0807-4e2b-ae3a-b8845f0597a6
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cbntthq23akg02mopjh0)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/183342059-03d29857-6a9b-45b9-9fd8-64c364dda7ca.png)

