### PR TITLE
Content ごとに crud/search の有無を指定できるよう対応

### DIFF
--- a/src/admin/contents/config.js
+++ b/src/admin/contents/config.js
@@ -2,6 +2,10 @@ import { headings, schemas, sections } from "./template";
 
 export default {
   label: "settings",
+  settings: {
+    update: true,
+    delete: false,
+  },
   sections: [
     {
       label: "メイン",

--- a/src/admin/contents/images.js
+++ b/src/admin/contents/images.js
@@ -2,6 +2,12 @@ import { headings, schemas, sections } from "./template";
 
 export default {
   label: "画像",
+  settings: {
+    search: true,
+    create: true,
+    update: true,
+    delete: true,
+  },
   headings: [
     {
       key: "url",

--- a/src/admin/contents/operators.js
+++ b/src/admin/contents/operators.js
@@ -2,6 +2,12 @@ import { headings, schemas, sections } from "./template";
 
 export default {
   label: "user",
+  settings: {
+    search: false,
+    create: false,
+    update: true,
+    delete: true,
+  },
   headings: [
     headings.id,
   ],

--- a/src/admin/contents/posts.js
+++ b/src/admin/contents/posts.js
@@ -2,6 +2,12 @@ import { headings, schemas, sections } from "./template";
 
 export default {
   label: "post",
+  settings: {
+    search: true,
+    create: true,
+    update: true,
+    delete: true,
+  },
   headings: [
     headings.image,
     headings.id,

--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -2,6 +2,12 @@ import { headings, schemas, sections } from "./template";
 
 export default {
   label: "user",
+  settings: {
+    search: true,
+    create: true,
+    update: true,
+    delete: true,
+  },
   headings: [
     Object.assign({}, headings.image, {
       key: 'icon_image.url',

--- a/src/lib/components/ContentList.svelte
+++ b/src/lib/components/ContentList.svelte
@@ -78,8 +78,9 @@
   div.p8
     form.f.flex-between.fm(on:submit|preventDefault='{onSearch}')
       div.f
-        input.input.mr4(bind:this='{queryElement}', type='search')
-        button.button 検索
+        +if('content.settings.search')
+          input.input.mr4(bind:this='{queryElement}', type='search')
+          button.button 検索
       div
         +if('content.actions')
           +each('content.actions as action')

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -12,6 +12,7 @@
     div.f.fm
       div.f.fm
       +each('actions as action')
-        button.button.ml8(type='button', class!='{action.kind || ""}', on:click='{action.onclick}') {action.label}
+        +if('!action.shouldShow || action.shouldShow()')
+          button.button.ml8(type='button', class!='{action.kind || ""}', on:click='{action.onclick}') {action.label}
       slot(name='right')
 </template>

--- a/src/routes/[...path].svelte
+++ b/src/routes/[...path].svelte
@@ -154,7 +154,10 @@
           kind: 'primary',
           onclick: () => {
             goto(`/${path}/new`);
-          }
+          },
+          shouldShow() {
+            return content.settings.create;
+          },
         },
       ];
     }
@@ -166,7 +169,10 @@
           kind: 'primary',
           onclick: () => {
             form.submit();
-          }
+          },
+          shouldShow() {
+            return content.settings.create;
+          },
         },
       ];
     }
@@ -179,7 +185,10 @@
           kind: 'danger',
           onclick: (e) => {
             onDelete(e);
-          }
+          },
+          shouldShow() {
+            return content.settings.delete;
+          },
         },
         // 保存
         {
@@ -187,7 +196,10 @@
           kind: 'primary',
           onclick: () => {
             form.submit();
-          }
+          },
+          shouldShow() {
+            return content.settings.update;
+          },
         },
       ];
     }


### PR DESCRIPTION
## 対応内容

- SSIA

## 確認方法

- [ ] settings のフラグに合わせて new や save, delete, search form の表示が切り替わってれば OK

## リンク

- 確認URL ... https://deploy-preview-73--svelte-admin-components.netlify.app/
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cc4sv4i23akg02kjevdg)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/187021240-b3edd670-1b9f-4a40-a694-6b85a4c5b057.png)

![image](https://user-images.githubusercontent.com/1156954/187021247-e89b4a53-bced-4356-8999-d113e35119cc.png)

