### PR TITLE
checkboxes の値を編集後に switch とかのフラグを変えるとリセットされるバグを修正

### DIFF
--- a/src/lib/forms/Checkboxes.svelte
+++ b/src/lib/forms/Checkboxes.svelte
@@ -12,6 +12,7 @@
   // svelte-ignore unused-export-let
   export let item;
 
+  let tempValue = value;
   let _choices = [];
 
   let setupChoices = async (choices) => {
@@ -19,22 +20,25 @@
     if (typeof choices === 'string') {
       // 共通の関数もしくは配列に変換
       choices = actions[choices];
+    }
 
-      if (typeof choices === 'function') {
-        _choices = await choices({schema, value});
-      }
-      else {
-        _choices = choices;
-      }
+    if (typeof choices === 'function') {
+      _choices = await choices({schema, value});
     }
     else {
       _choices = choices;
     }
   };
 
+
   onMount(() => {
     setupChoices(schema.opts.choices);
   });
+
+  // svelte-ignore unused-export-let
+  export let getValue = () => {
+    return tempValue;
+  };
 </script>
 
 <template lang='pug'>
@@ -46,6 +50,6 @@
     div.f.fm
       +each('_choices as choice')
         label.f.fm.mr16
-          input.mr4(type='checkbox', bind:group='{value}', value='{choice.value}')
+          input.mr4(type='checkbox', bind:group='{tempValue}', value='{choice.value}')
           span(value='{choice.value}') {choice.label || choice.value}
 </template>

--- a/src/lib/forms/Radio.svelte
+++ b/src/lib/forms/Radio.svelte
@@ -12,6 +12,7 @@
   // svelte-ignore unused-export-let
   export let item;
 
+  let tempValue = value;
   let _choices = [];
 
   let setupChoices = async (choices) => {
@@ -19,13 +20,10 @@
     if (typeof choices === 'string') {
       // 共通の関数もしくは配列に変換
       choices = actions[choices];
+    }
 
-      if (typeof choices === 'function') {
-        _choices = await choices({schema, value});
-      }
-      else {
-        _choices = choices;
-      }
+    if (typeof choices === 'function') {
+      _choices = await choices({schema, value});
     }
     else {
       _choices = choices;
@@ -35,6 +33,11 @@
   onMount(() => {
     setupChoices(schema.opts.choices);
   });
+
+  // svelte-ignore unused-export-let
+  export let getValue = () => {
+    return tempValue;
+  };
 </script>
 
 <template lang='pug'>
@@ -46,6 +49,6 @@
     div.f.fm
       +each('_choices as choice')
         label.f.fm.mr16
-          input.mr4(type='radio', bind:group='{value}', value='{choice.value}')
+          input.mr4(type='radio', bind:group='{tempValue}', value='{choice.value}')
           span(value='{choice.value}') {choice.label || choice.value}
 </template>


### PR DESCRIPTION
## 対応内容

- SSIA
- bind:group の仕様が、each で回してるオブジェクトの参照が変わるとリセットされる仕様らしい... のでその対策
- 今まで起きていなかったのは choices が固定の配列だったから

## 確認方法

- [ ] デグレってなければ OK

## リンク

- 確認URL ... 
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cc7iq0q23akg02hodggg)

## スクショ

起きていた現象

https://www.awesomescreenshot.com/video/10808815?key=88d0a8b82cdf1c9fbd745bb6d8993949

これマージしたら治るはず...

