### PR TITLE
Header のパンくず対応

### DIFF
--- a/src/admin/contents/config.js
+++ b/src/admin/contents/config.js
@@ -1,7 +1,7 @@
 import { headings, schemas, sections } from "$admin/contents/template";
 
 export default {
-  label: "settings",
+  label: "コンフィグ",
   settings: {
     update: true,
     delete: false,

--- a/src/admin/contents/posts.js
+++ b/src/admin/contents/posts.js
@@ -1,7 +1,7 @@
 import { headings, schemas, sections } from "$admin/contents/template";
 
 export default {
-  label: "post",
+  label: "投稿",
   settings: {
     search: true,
     create: true,
@@ -149,7 +149,7 @@ export default {
   ],
   // コメント
   comments: {
-    label: "post comments",
+    label: "コメント",
     settings: {
       search: true,
       create: true,

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,7 +1,9 @@
 <script>
   export {className as class};
+  export let path;
   export let label;
-  export let actions = [];
+  export let actions;
+  export let buttons = [];
 
   let className = null;
 </script>
@@ -11,8 +13,8 @@
     h1.fs16 {label}
     div.f.fm
       div.f.fm
-      +each('actions as action')
-        +if('!action.shouldShow || action.shouldShow()')
-          button.button.ml8(type='button', class!='{action.kind || ""}', on:click='{action.onclick}') {action.label}
+      +each('buttons as button')
+        +if('!button.shouldShow || button.shouldShow()')
+          button.button.ml8(type='button', class!='{button.kind || ""}', on:click='{button.onclick}') {button.label}
       slot(name='right')
 </template>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -6,11 +6,45 @@
   export let buttons = [];
 
   let className = null;
+  let breadcrumbs = [];
+
+  $: {
+    breadcrumbs = [];
+
+    let pathes = path.split('/');
+    let temp_pathes = [];
+
+    pathes.forEach((p, i) => {
+      temp_pathes.push(p);
+
+      let label = p;
+      let temp_path = temp_pathes.join('/');
+
+      if (i%2 === 0) {
+        let content = actions.pathToContent(temp_path);
+
+        if (content) {
+          label = content.label;
+        }
+      }
+
+      breadcrumbs.push({
+        label,
+        link: `/${temp_path}`,
+      });
+    });
+  }
 </script>
 
 <template lang="pug">
   div.f.fm.flex-between(class='{className}')
-    h1.fs16 {label}
+    div.overflow-scroll
+      h1.fs14.f
+        +each('breadcrumbs as breadcrumb,i')
+          a.flex-fixed(href='{breadcrumb.link}') {breadcrumb.label} 
+          +if('i < (breadcrumbs.length-1)')
+            span.mx4 / 
+
     div.f.fm
       div.f.fm
       +each('buttons as button')

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -38,12 +38,11 @@
 
 <template lang="pug">
   div.f.fm.flex-between(class='{className}')
-    div.overflow-scroll
-      h1.fs14.f
-        +each('breadcrumbs as breadcrumb,i')
-          a.flex-fixed(href='{breadcrumb.link}') {breadcrumb.label} 
-          +if('i < (breadcrumbs.length-1)')
-            span.mx4 / 
+    h1.fs14.f.fm.overflow-scroll
+      +each('breadcrumbs as breadcrumb,i')
+        a.flex-fixed(href='{breadcrumb.link}') {breadcrumb.label}
+        +if('i < (breadcrumbs.length-1)')
+          span.fs11.text-gray.mx4 /
 
     div.f.fm
       div.f.fm

--- a/src/routes/[...path].svelte
+++ b/src/routes/[...path].svelte
@@ -141,11 +141,7 @@
     history.back();
   };
 
-  let getHeaderLabel = (path) => {
-    return id ? `${content.label} / ${id}` : content.label;
-  };
-
-  let getHeaderActions = (path) => {
+  let getHeaderButtons = (path) => {
     if (mode === 'list') {
       // 一覧
       return [
@@ -215,7 +211,7 @@
 
 <template lang="pug">
   main.s-full.overflow-scroll
-    Header.p16.sticky.t0.box-shadow.bg-white.relative.z100(label='{getHeaderLabel(path)}', actions='{getHeaderActions(path)}')
+    Header.p16.sticky.t0.box-shadow.bg-white.relative.z100(path='{path}', actions='{actions}', buttons='{getHeaderButtons(path)}')
 
     div.p16
       +if('mode === "list"')


### PR DESCRIPTION
## 対応内容

- path を元にパンくずを構築して表示するよう対応
- Header に渡していたボタン用のプロパティ actions が名前かぶったので buttons に変更

## 確認方法

- [ ] [コメント詳細](https://deploy-preview-78--svelte-admin-components.netlify.app/posts/0d6a1831-c87a-4df5-96fd-f1ad837ae80c/comments/a091b3ec-8b53-4862-9e1a-9d14fe72e521)とかでちゃんと Header にパンくずが表示されてれば OK
- [ ] それぞれリンクとして機能していれば OK
- [ ] 他デグレってなければ OK

## リンク

- 確認URL ... https://deploy-preview-78--svelte-admin-components.netlify.app/posts/0d6a1831-c87a-4df5-96fd-f1ad837ae80c/comments/a091b3ec-8b53-4862-9e1a-9d14fe72e521
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/ccklski23akg02jnat40)

## スクショ

![image](https://user-images.githubusercontent.com/1156954/191227266-56141c3c-bd2b-4818-adf3-ebdca073a22c.png)


