### PR TITLE
値が null だったら `(未設定)` を表示するよう対応

### DIFF
--- a/src/admin/contents/operators.js
+++ b/src/admin/contents/operators.js
@@ -10,6 +10,7 @@ export default {
   },
   headings: [
     headings.id,
+    headings.name,
   ],
   sections: [
     {
@@ -17,6 +18,7 @@ export default {
       class: "col12 mb16",
       schemas: [
         schemas.id,
+        schemas.name,
       ],
     },
     {

--- a/src/admin/dummy.js
+++ b/src/admin/dummy.js
@@ -65,8 +65,7 @@ export function operator() {
   return {
     id: faker.datatype.uuid(),
     // id: '1',
-    screen_name: name.toLowerCase(),
-    display_name: name,
+    name: [name, '', null][faker.datatype.number() % 3],
     bio: faker.lorem.lines(),
     icon_image: image(),
     followers_count: faker.datatype.number() % 1000,

--- a/src/lib/contents/Text.svelte
+++ b/src/lib/contents/Text.svelte
@@ -45,5 +45,9 @@
 </script>
 
 <template lang='pug'>
-  p.line-clamp-3 {_value}
+  p.line-clamp-3
+    +if('_value !== null')
+      | {_value}
+      +else
+        | (未設定)
 </template>


### PR DESCRIPTION
## 対応内容

- SSIA

## 確認方法

- [ ] 文字列 ... そのまま表示
- [ ] 空文字('') ... 空欄
- [ ] null ... `(未設定)`

## リンク

- 確認URL ... https://deploy-preview-80--svelte-admin-components.netlify.app/operators
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cckieuq23akg02h7kd30)

## スクショ

![image.png](https://storage.googleapis.com/content-alog-rabee-jp/user_upload/LlVgPzShFlXLJLXfumhO2qsPckn1_cckuja223akg02jg47v0)
