### PR TITLE
switchにreadonly実装

### DIFF
--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -110,6 +110,14 @@ export default {
           type: "switch"
         },
         {
+          key: "editable",
+          label: "編集権限",
+          type: "switch",
+          opts: {
+            readonly: true,
+          }
+        },
+        {
           key: "created_at",
           label: "作成日",
           type: "date",

--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -110,8 +110,8 @@ export default {
           type: "switch"
         },
         {
-          key: "editable",
-          label: "編集権限",
+          key: "is_official",
+          label: "公式",
           type: "switch",
           opts: {
             readonly: true,

--- a/src/admin/dummy.js
+++ b/src/admin/dummy.js
@@ -16,7 +16,6 @@ export function image() {
 export function user() {
   const GENDERS = ['male', 'female', 'other'];
   let name = faker.name.firstName();
-  let isBool = faker.datatype.number() % 2;
   
   return {
     id: faker.datatype.uuid(),
@@ -31,7 +30,7 @@ export function user() {
     age: faker.datatype.number({min: 18, max: 64}),
     gender: GENDERS[faker.datatype.number() % 3],
     roles: ['member'],
-    is_official: isBool,
+    is_official: faker.datatype.boolean(),
   };
 };
 

--- a/src/admin/dummy.js
+++ b/src/admin/dummy.js
@@ -16,6 +16,7 @@ export function image() {
 export function user() {
   const GENDERS = ['male', 'female', 'other'];
   let name = faker.name.firstName();
+  let isBool = faker.datatype.number() % 2;
   
   return {
     id: faker.datatype.uuid(),
@@ -30,6 +31,7 @@ export function user() {
     age: faker.datatype.number({min: 18, max: 64}),
     gender: GENDERS[faker.datatype.number() % 3],
     roles: ['member'],
+    is_official: isBool,
   };
 };
 

--- a/src/lib/forms/Switch.svelte
+++ b/src/lib/forms/Switch.svelte
@@ -17,7 +17,7 @@
   label.inline-block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.switch.text-primary(type='checkbox' bind:checked='{value}' class:checked='{value}', on:change)
+    input.switch.text-primary(type='checkbox', bind:checked='{value}', class:checked='{value}', disabled!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
 </template>
 
 <style lang='less' global>

--- a/src/lib/forms/Switch.svelte
+++ b/src/lib/forms/Switch.svelte
@@ -17,7 +17,7 @@
   label.inline-block
     +if('schema.label')
       div.fs12.mb4 {schema.label}
-    input.switch.text-primary(type='checkbox', bind:checked='{value}', class:checked='{value}', disabled!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change)
+    input.switch.text-primary(type='checkbox', bind:checked='{value}', class:checked='{value}', disabled!='{schema.opts?.readonly}', class:opacity-30='{schema.opts?.readonly}', on:change)
 </template>
 
 <style lang='less' global>


### PR DESCRIPTION
## 対応内容
- SSIA

## 確認方法
- [ ] user 内の[公式]箇所にreadonlyが適用されているか

## リンク
- 確認URL ... https://deploy-preview-83--svelte-admin-components.netlify.app/users
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/ccm0coq23akg02uvr53g)

## スクショ
readonly が false の時
![image](https://user-images.githubusercontent.com/68733389/191733219-9e5895c3-a1d7-4e5c-8811-452724cfd28a.png)

readonly が true の時
![image](https://user-images.githubusercontent.com/68733389/192179557-eed2f10e-a8fe-47c6-a78e-12b4bf123981.png)


readonly が true, かつダミーデータがtrueの時
![image](https://user-images.githubusercontent.com/68733389/192179568-35085a34-a555-4219-b2a3-0574687a1a0f.png)

