### PR TITLE
サイドバーのハイライトの条件を修正

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -15,6 +15,13 @@
     }
     return true;
   };
+
+  const isActive = (item, pathname) => {
+    const item_paths = item.link.split('/');
+    const paths = pathname.split('/');
+    return item_paths.every((p, i) => p === paths[i]);
+  };
+
 </script>
 
 <template lang='pug'>
@@ -35,7 +42,7 @@
             +each('section.items as item')
               +if('shouldShow(item)')
                 div.pl8.rounded-8.hover-trigger.hover-bg-light
-                  a.block.pl8.py3.fs16(href='{item.link}', class!="{$page.url.pathname.indexOf(item.link) === 0 ? 'pl16 bg-white rounded-top-left-full rounded-bottom-left-full text-primary bold mrn16 mln8' : ''}")
+                  a.block.pl8.py3.fs16(href='{item.link}', class!="{isActive(item, $page.url.pathname) ? 'pl16 bg-white rounded-top-left-full rounded-bottom-left-full text-primary bold mrn16 mln8' : ''}")
                     div {item.label}
 </template>
 


### PR DESCRIPTION
## 対応内容

- サイドバーのハイライトの条件を修正
- 例)  path が post2 で post のサイドバーが光ってしまう のを修正

## 確認方法

- [ ] admin のサイドバーを色々いじって確認

## リンク

- 確認URL ... ローカルで確認
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cdgd68q23akg02laccn0)


## スクショ


<img width="202" alt="image" src="https://user-images.githubusercontent.com/8247441/199188156-c61dd95f-817d-442e-94b1-1591243ce949.png">

