### PR TITLE
inputのtype='date'にて入力値を削除した際に`0`を返すように修正

### DIFF
--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -129,7 +129,7 @@ export default {
           opts: {
             is_unixtime: true,
             date_type: "",
-            readonly: true,
+            // readonly: true,
             required: true
           }
         },

--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -129,8 +129,7 @@ export default {
           opts: {
             is_unixtime: true,
             date_type: "",
-            // readonly: true,
-            required: true
+            // readonly: true
           }
         },
         {

--- a/src/lib/forms/Date.svelte
+++ b/src/lib/forms/Date.svelte
@@ -35,10 +35,11 @@
     let v = input.value;
 
     if (schema.opts.is_unixtime) {
+      if (!v) return 0;
+
       // return dayjs(v).unix();
       return dayjs(v).valueOf();
     }
-
     return v;
   };
 


### PR DESCRIPTION
## 対応内容
- 既に値が入っている状態で、カレンダー左下の`削除`ボタンから値を空にした際に、`null`が入っていたのを`0`に変更
- 修正背景としては、DBの初期値が 0 な事と、間違って入力した際に 0 にする術がなかったため

補足
 - あくまで使う側で、is_unixtime = true を選択した際のみ 0 が返る

## 確認方法
以下確認お願いします
- [ ] save時に、consoleに表示される保存後のデータを確認いただき、削除した際に0が入ってるか

## リンク
- 確認URL ... https://deploy-preview-88--svelte-admin-components.netlify.app/users/e0ab7da8-a50c-4e18-bf86-bc173d689eee
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cfgb47q23akg02h0nef0)

## スクショ
![image](https://user-images.githubusercontent.com/68733389/216916008-0e8c51cc-8f9a-45a8-beb5-c4fed56ad161.png)

