### PR TITLE
textareaにドラッグした画像サイズに応じてimgixで表示サイズを制限する

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -116,9 +116,27 @@ const admin = {
 
         return item && item.url;
       },
-      upload({value, file}) {
+      async upload({value, file}) {
         let url = URL.createObjectURL(file);
-        return url;
+
+        const image = new Image();
+        image.src = url;
+
+        let loadImage = new Promise((resolve) => {
+          image.addEventListener('load', () => {
+            resolve({
+              width: image.naturalWidth,
+              height: image.naturalHeight,
+            });
+          });
+        });
+        let {width = 0, height = 0} = await loadImage;
+
+        return {
+          url,
+          width,
+          height,
+        };
       },
     },
 

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -122,7 +122,7 @@ const admin = {
         const image = new Image();
         image.src = url;
 
-        let loadImage = new Promise((resolve) => {
+        let loadImagePromise = new Promise((resolve) => {
           image.addEventListener('load', () => {
             resolve({
               width: image.naturalWidth,
@@ -130,7 +130,7 @@ const admin = {
             });
           });
         });
-        let {width = 0, height = 0} = await loadImage;
+        let {width = 0, height = 0} = await loadImagePromise;
 
         return {
           url,

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -19,9 +19,11 @@
     // 画像以外は弾く
     if (/^image/.test(file.type) === false) return ;
 
-    let url = await actions.image.upload({
+    let { url, width, height } = await actions.image.upload({
       file,
     });
+
+    console.log(url, width, height, 'upload');
 
     let text = `![${file.name}](${url})`;
 

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -25,7 +25,7 @@
       file,
     });
 
-    let imgix_url = getImgixUrl(url, width < 2000 ? width : 2000);
+    let imgix_url = getImgixUrl(url, (width < 2000 ? width : 2000));
 
     let text = `![${file.name}](${imgix_url})`;
 

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -25,7 +25,7 @@
       file,
     });
 
-    let imgix_url = getImgixUrl(url, (width < 2000 ? width : 2000));
+    let imgix_url = getImgixUrl(url, (width >= 2000 ? 2000 : null));
 
     let text = `![${file.name}](${imgix_url})`;
 

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -1,6 +1,8 @@
 <svelte:options accessors={true}/>
 
 <script>
+  import { getImgixUrl } from "$lib/utils";
+
   export let schema;
   export let value = '';
   // svelte-ignore unused-export-let
@@ -23,9 +25,9 @@
       file,
     });
 
-    console.log(url, width, height, 'upload');
+    let imgix_url = getImgixUrl(url, width < 2000 ? width : 2000);
 
-    let text = `![${file.name}](${url})`;
+    let text = `![${file.name}](${imgix_url})`;
 
     // 差し込む
     let cursor_position = textareaElement.selectionStart;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -36,14 +36,16 @@ export function pathToContent(contents, path) {
 };
 
 // imgix画像の取得
-export function getImgixUrl(image, width = null, height = null) {
+export function getImgixUrl(image, width=null, height=null, fit='crop') {
+  // 既にimgix_urlの場合には return
+  // if (!/imgix\.net/.test(image)) return image;
   let dpr = (typeof devicePixelRatio === 'number') ? devicePixelRatio : 1;
-  let url = `${image}?auto=format&cs=srgb&fit=crop&dpr=${dpr}`;
-  if (width) {
-    url += `&w=${width}`;
-  }
-  if (height) {
-    url += `&h=${height}`;
-  }
-  return url;
+  let url_obj = new URL(image);
+  let query_array = Object.entries({ auto: 'format', cs: 'srgb', fit, dpr, width, height });
+
+  query_array.forEach(([key, value]) => {
+    if (!value) return ;
+    url_obj.searchParams.set(key, String(value));
+  });
+  return url_obj.href;
 };

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -41,7 +41,14 @@ export function getImgixUrl(image, width=null, height=null, fit='crop') {
   // if (!/imgix\.net/.test(image)) return image;
   let dpr = (typeof devicePixelRatio === 'number') ? devicePixelRatio : 1;
   let url_obj = new URL(image);
-  let query_array = Object.entries({ auto: 'format', cs: 'srgb', fit, dpr, width, height });
+  let query_array = Object.entries({
+    auto: 'format',
+    cs: 'srgb',
+    fit,
+    dpr,
+    width,
+    height
+  });
 
   query_array.forEach(([key, value]) => {
     if (!value) return ;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -34,3 +34,16 @@ export function pathToContent(contents, path) {
 
   return getByPath(contents, content_id);
 };
+
+// imgix画像の取得
+export function getImgixUrl(image, width = null, height = null) {
+  let dpr = (typeof devicePixelRatio === 'number') ? devicePixelRatio : 1;
+  let url = `${image}?auto=format&cs=srgb&fit=crop&dpr=${dpr}`;
+  if (width) {
+    url += `&w=${width}`;
+  }
+  if (height) {
+    url += `&h=${height}`;
+  }
+  return url;
+};


### PR DESCRIPTION
## 対応内容
- textareaにimageをドラッグした際に、最大2000pxになるようimgix-urlを調整するよう実装

補足
実際に生成されたimage-urlを叩いても表示されないのはスルーで大丈夫です　※確認済み

参考 widthが2000px以上の画像
https://4.bp.blogspot.com/-pYPo3b2FK1o/Un13jFQKxqI/AAAAAAAAEVA/QODDc1e_1LA/s2048/BENTLEY-Wallpaper-7322034272_2e734bc751_k.jpg

## 確認方法
- [ ] 上記参考画像をtextareaにドラッグ&ドロップした際に、`&w=2000`が入っているか
- [ ] ~~widthが2000px以下の画像をドラッグ&ドロップした際には、その画像のサイズが末尾にくっつくか~~

## リンク
- 確認URL ... https://deploy-preview-89--svelte-admin-components.netlify.app/users/0fe1ade0-08e6-4f8c-9f35-0d8cdb5a3418
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cfmsg4q23akg02qunrog?view=board)

## スクショ
[![Gyazo](https://i.gyazo.com/thumb/1200/e5a9db83c16dda36c35255a44865955b-gif.gif)](https://gyazo.com/e5a9db83c16dda36c35255a44865955b)