### PR TITLE
markdown editor の内容が保存した時に反映されないのを修正

### DIFF
--- a/src/lib/forms/Markdown.svelte
+++ b/src/lib/forms/Markdown.svelte
@@ -47,9 +47,6 @@
       .config((ctx) => {
         ctx.set(rootCtx, element);
         ctx.set(defaultValueCtx, value);
-        ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
-            value = markdown;
-        });
         ctx.update(editorViewOptionsCtx, (prev) => ({
           ...prev,
           editable,
@@ -67,7 +64,7 @@
   };
 
   // 値を取得
-  export const getMarkdown = () => {
+  export const getValue = () => {
     let value = editor.action((ctx) => {
       const editorView = ctx.get(editorViewCtx);
       const serializer = ctx.get(serializerCtx);


### PR DESCRIPTION
## 対応内容

- 新規、編集に関わらず markdown editor の内容を入力後に categories や作者を変更して保存すると入力した情報が反映されないのを修正
- markdown.svelte の value の渡し方を getValue に変更

## 確認方法

- [ ]  markdown editor の内容を入力後に categories や作者を変更して保存した時に変更が反映されているかご確認お願いいたします

## リンク

- 確認URL ... https://deploy-preview-100--svelte-admin-components.netlify.app/posts/3cfaa348-c31b-4f40-bee4-fcf0c42b78f1
- [関連チケット(menuble の admin で今回の事象が発覚しました)](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/39FwotcHXG5ESnU2rkX6/notes/ch7kpq223akg02quj4e0)
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/ch7njm223akg02quld90)

## スクショ

[![Image from Gyazo](https://i.gyazo.com/05647ebc9cbc9463729d46f50d186ac5.gif)](https://gyazo.com/05647ebc9cbc9463729d46f50d186ac5)