### PR TITLE
markdown editor に actions を仕込めるよう対応

### DIFF
--- a/src/admin/contents/posts.js
+++ b/src/admin/contents/posts.js
@@ -1,4 +1,5 @@
 import { headings, schemas, sections } from "$admin/contents/template";
+import { openModal } from "svelte-modal-manager";
 
 export default {
   label: "投稿",
@@ -51,7 +52,26 @@ export default {
           type: "markdown",
           class: "",
           opts: {
-            cols: ""
+            cols: "",
+            actions: [
+              {
+                label: 'image',
+                onclick: ({insertValue, value, actions}) => {
+                  let modal = openModal('admin-content', {
+                    path: 'images',
+                    actions,
+                  });
+
+                  modal.$on('select', (e) => {
+                    let item = e.detail.item;
+
+                    insertValue(`![${item.name}](${item.url})`);
+
+                    modal.close();
+                  });              
+                },
+              }
+            ]
           }
         },
         {

--- a/src/lib/forms/Markdown.svelte
+++ b/src/lib/forms/Markdown.svelte
@@ -98,6 +98,15 @@
     insertValue(text);
   };
 
+  const onAction = async (action) => {
+    await action.onclick({
+      value,
+      item,
+      actions,
+      insertValue,
+    });
+  };
+
 </script>
 
 <template lang='pug'>
@@ -106,5 +115,8 @@
       div.fs12.mb4 {schema.label} 
         +if('schema.opts?.required')
           span *
-    div.markdown-styles.w-full.border.rounded-4.p8(bind:this='{editorElement}', rows='{schema.opts?.cols || 8}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change, on:dragover|preventDefault!='{() => {}}', on:drop|preventDefault='{onDrop}')
+  div.mb4
+    +each('schema.opts.actions || [] as action')
+      button.button.px8.py6.fs12(type='button', on:click!='{() => {onAction(action)}}') {action.label}
+  div.markdown-styles.w-full.border.rounded-4.p8(bind:this='{editorElement}', rows='{schema.opts?.cols || 8}', readonly!='{schema.opts?.readonly}', class:bg-whitesmoke='{schema.opts?.readonly}', on:change, on:dragover|preventDefault!='{() => {}}', on:drop|preventDefault='{onDrop}')
 </template>


### PR DESCRIPTION
## 対応内容

- opts に actions を設定することでエディタ上部にボタンを並べることができる

## 確認方法

- [ ] [post 詳細](https://deploy-preview-101--svelte-admin-components.netlify.app/posts/3cfaa348-c31b-4f40-bee4-fcf0c42b78f1)を開く
- [ ] markdown のところで `image` ボタンをクリック
- [ ] 画像を選ぶと挿入される

## リンク

- 確認URL ... https://deploy-preview-101--svelte-admin-components.netlify.app/posts/3cfaa348-c31b-4f40-bee4-fcf0c42b78f1
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cin4ati23akg0361c7u0)

## スクショ

![image](https://github.com/rabee-inc/svelte-admin-components/assets/1156954/a0547d23-6cf2-4cea-91da-7cd40f100840)
