### PR TITLE
modal-managerとsvelte-headをrabee-orgのパッケージに変更する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 !.env.example
 .vercel
 .output
+
+_svelte-modal-manager-types

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "meltline": "^0.1.15",
     "pug": "^3.0.2",
     "svelte": "^3.55.1",
-    "svelte-head": "^0.0.6",
     "@tailwindcss/typography": "^0.5.9",
     "tailwindcss": "^3.3.1",
     "svelte2tsx": "^0.6.10",
@@ -68,6 +67,7 @@
     "@milkdown/prose": "7.1.1",
     "@milkdown/theme-nord": "7.1.1",
     "@milkdown/transformer": "7.1.1",
+    "@rabee-org/svelte-head": "^0.1.0",
     "@rabee-org/svelte-modal-manager": "^0.1.0",
     "dayjs": "^1.11.0",
     "sortablejs": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
     "@milkdown/prose": "7.1.1",
     "@milkdown/theme-nord": "7.1.1",
     "@milkdown/transformer": "7.1.1",
+    "@rabee-org/svelte-modal-manager": "^0.1.0",
     "dayjs": "^1.11.0",
-    "sortablejs": "^1.15.0",
-    "svelte-modal-manager": "^0.0.7"
+    "sortablejs": "^1.15.0"
   },
   "files": ["package"],
   "main": "./package/index.js",

--- a/package.json
+++ b/package.json
@@ -68,9 +68,10 @@
     "@milkdown/theme-nord": "7.1.1",
     "@milkdown/transformer": "7.1.1",
     "@rabee-org/svelte-head": "^0.1.0",
-    "@rabee-org/svelte-modal-manager": "^0.1.0",
+    "@rabee-org/svelte-modal-manager": "0.2.1",
     "dayjs": "^1.11.0",
-    "sortablejs": "^1.15.0"
+    "sortablejs": "^1.15.0",
+    "modal:create": "svelte-modal-manager create -t=pug -d ./src/components/modals -s less"
   },
   "files": ["package"],
   "main": "./package/index.js",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "deploy": "NODE_ENV=development npm run build; gcloud app deploy --project $npm_package_config_gae_stg gae_stg.yaml --version svelte -q",
     "deploy:prod": "npm run build; gcloud app deploy --project $npm_package_config_gae_prod gae_prod.yaml --version svelte -q",
     "release": "npm run package && npm publish",
-    "icon": "fontcustom compile ./static/images/icons --font_name icons --output static/icons/"
+    "icon": "fontcustom compile ./static/images/icons --font_name icons --output static/icons/",
+    "modal:create": "svelte-modal-manager create -t=pug -d ./src/components/modals -s less"
   },
   "devDependencies": {
     "@faker-js/faker": "^6.1.1",
@@ -70,8 +71,7 @@
     "@rabee-org/svelte-head": "^0.1.0",
     "@rabee-org/svelte-modal-manager": "0.2.1",
     "dayjs": "^1.11.0",
-    "sortablejs": "^1.15.0",
-    "modal:create": "svelte-modal-manager create -t=pug -d ./src/components/modals -s less"
+    "sortablejs": "^1.15.0"
   },
   "files": ["package"],
   "main": "./package/index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "deploy:prod": "npm run build; gcloud app deploy --project $npm_package_config_gae_prod gae_prod.yaml --version svelte -q",
     "release": "npm run package && npm publish",
     "icon": "fontcustom compile ./static/images/icons --font_name icons --output static/icons/",
-    "modal:create": "svelte-modal-manager create -t=pug -d ./src/components/modals -s less"
+    "modal:create": "svelte-modal-manager create -t=pug -d ./src/lib/modals -s less"
   },
   "devDependencies": {
     "@faker-js/faker": "^6.1.1",

--- a/src/admin/contents/posts.js
+++ b/src/admin/contents/posts.js
@@ -1,5 +1,5 @@
 import { headings, schemas, sections } from "$admin/contents/template";
-import { openModal } from "@rabee-org/svelte-modal-manager";
+import { modalContent } from "$modal";
 
 export default {
   label: "投稿",
@@ -57,7 +57,7 @@ export default {
               {
                 label: 'image',
                 onclick: ({insertValue, value, actions}) => {
-                  let modal = openModal('admin-content', {
+                  let modal = modalContent.open({
                     path: 'images',
                     actions,
                   });

--- a/src/admin/contents/posts.js
+++ b/src/admin/contents/posts.js
@@ -1,5 +1,5 @@
 import { headings, schemas, sections } from "$admin/contents/template";
-import { openModal } from "svelte-modal-manager";
+import { openModal } from "@rabee-org/svelte-modal-manager";
 
 export default {
   label: "投稿",

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,7 +1,7 @@
 
 import { goto } from '$app/navigation';
 import { pathToContent } from 'svelte-admin-components';
-import { openModal } from 'svelte-modal-manager';
+import { openModal } from '@rabee-org/svelte-modal-manager';
 import contents from './contents/index.js';
 
 let isGuest = () => {

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,7 +1,7 @@
 
 import { goto } from '$app/navigation';
 import { pathToContent } from 'svelte-admin-components';
-import { openModal } from '@rabee-org/svelte-modal-manager';
+import { modalContent } from '$modal';
 import contents from './contents/index.js';
 
 let isGuest = () => {
@@ -102,7 +102,7 @@ const admin = {
     image: {
       async select() {
         // 画像選択モーダル開いたり
-        let modal = openModal('admin-content', {
+        let modal = modalContent.open({
           path: 'images',
           actions: admin.actions,
         });

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,6 @@
 
 // setup head
-import {setOptions} from 'svelte-head';
+import { setOptions } from '@rabee-org/svelte-head';
 
 setOptions({
   title(title) {

--- a/src/lib/forms/Content.svelte
+++ b/src/lib/forms/Content.svelte
@@ -3,7 +3,7 @@
 <script>
   import { getByPath } from "$lib/utils";
   import { onMount } from "svelte";
-  import { openModal } from 'svelte-modal-manager';
+  import { openModal } from '@rabee-org/svelte-modal-manager';
 
   export let path;
   export let schema;

--- a/src/lib/forms/Content.svelte
+++ b/src/lib/forms/Content.svelte
@@ -3,7 +3,7 @@
 <script>
   import { getByPath } from "$lib/utils";
   import { onMount } from "svelte";
-  import { openModal } from '@rabee-org/svelte-modal-manager';
+  import { modalContent } from "$modal";
 
   export let path;
   export let schema;
@@ -28,7 +28,7 @@
   });
 
   let openContentModal = () => {
-    let modal = openModal('admin-content', {
+    let modal = modalContent.open({
       path: schema.opts.content_path,
       actions,
     });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -327,11 +327,3 @@ export const SCHEMA_CONTENT = [
     ]
   }
 ];
-
-
-// setup modal
-import { registerModalComponent } from '@rabee-org/svelte-modal-manager';
-
-import * as ContentModal from './modals/Content.svelte';
-
-registerModalComponent('admin-content', ContentModal);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -330,7 +330,7 @@ export const SCHEMA_CONTENT = [
 
 
 // setup modal
-import { registerModalComponent } from 'svelte-modal-manager';
+import { registerModalComponent } from '@rabee-org/svelte-modal-manager';
 
 import * as ContentModal from './modals/Content.svelte';
 

--- a/src/lib/modals/Content.svelte
+++ b/src/lib/modals/Content.svelte
@@ -1,27 +1,43 @@
 <svelte:options accessors={true}/>
 
+<script context="module">
+  /** @type {import('@rabee-org/svelte-modal-manager/types').ModalDefaultOptions} */
+  export const { dismissible, position, focus, transition, overlay, timeout } = {
+    // dismissible: false,
+    // position: { x: 'center', y: 'middle' },
+    // focus: false,
+    // transition: {
+    //   type: fly,
+    //   props: {
+    //     y: 8,
+    //     duration: 256,
+    //   },
+    // },
+    // overlay: {
+    //   styles: {
+    //     background: 'rgba(0, 0, 0, 0.75)',
+    //   },
+    // },
+    // timeout: 2000,
+  };
+</script>
+
 <script>
   import ContentList from '$lib/components/ContentList.svelte';
   import { getByPath } from '$lib/utils';
-
-  import { createEventDispatcher, onMount } from 'svelte';
-  export const dispatch = createEventDispatcher();
-  // svelte-ignore unused-export-let
-  export let close;
-  // svelte-ignore unused-export-let
-  export let awaitClose;
+  import { getModalContext } from '@rabee-org/svelte-modal-manager';
+  
+  const { close, awaitClose, result, isClosed, dispatch } = getModalContext();
 
   export let path;
   export let actions;
 
-  export let value;
-
   let content = actions.pathToContent(path);
 
   let onSelect = (e) => {
-    value = e.detail.item;
+    $result = e.detail.item;
     dispatch('select', {
-      item: value,
+      item: $result,
     });
   };
 

--- a/src/lib/modals/_svelte-modal-manager-types/Content.d.ts
+++ b/src/lib/modals/_svelte-modal-manager-types/Content.d.ts
@@ -1,0 +1,5 @@
+declare module '$modal' {
+  import type { ModalControllerProxy } from "@rabee-org/svelte-modal-manager/types";
+  import type * as Content from "$modals/Content.svelte";
+  export const modalContent: ModalControllerProxy<typeof Content, any>;
+}

--- a/src/lib/modals/_svelte-modal-manager-types/Content.d.ts
+++ b/src/lib/modals/_svelte-modal-manager-types/Content.d.ts
@@ -1,5 +1,0 @@
-declare module '$modal' {
-  import type { ModalControllerProxy } from "@rabee-org/svelte-modal-manager/types";
-  import type * as Content from "$modals/Content.svelte";
-  export const modalContent: ModalControllerProxy<typeof Content, any>;
-}

--- a/src/lib/scripts/modal.js
+++ b/src/lib/scripts/modal.js
@@ -1,0 +1,23 @@
+import { modalAlert, modalConfirm, modalIndicator } from "@rabee-org/svelte-modal-manager";
+
+export const indicator = modalIndicator.open;
+
+/**
+ * 
+ * @param {string} message 
+ * @param {Parameters<typeof modalAlert.openSync>[0]} [props] 
+ * @returns 
+ */
+export function alert(message, props) {
+  return modalAlert.openSync({ message, ...props });
+}
+
+/**
+ * 
+ * @param {string} message 
+ * @param {Parameters<typeof modalConfirm.openSync>[0]} [props] 
+ * @returns 
+ */
+export function confirm(message, props) {
+  return modalConfirm.openSync({ message, ...props });
+}

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -5,7 +5,7 @@
   import { page } from "$app/stores";
   import admin from "$admin/index.js"
   import { onMount } from "svelte";
-  import { indicator } from "@rabee-org/svelte-modal-manager";
+  import { indicator } from "$lib/scripts/modal";
   import { ContentList, ContentForm, Header } from "svelte-admin-components";
 
   $: ({ path, mode, id, content } = $page.data);

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -5,7 +5,7 @@
   import { page } from "$app/stores";
   import admin from "$admin/index.js"
   import { onMount } from "svelte";
-  import { indicator } from "svelte-modal-manager";
+  import { indicator } from "@rabee-org/svelte-modal-manager";
   import { ContentList, ContentForm, Header } from "svelte-admin-components";
 
   $: ({ path, mode, id, content } = $page.data);

--- a/src/routes/[...path]/+page.svelte
+++ b/src/routes/[...path]/+page.svelte
@@ -1,7 +1,7 @@
 <script>
 
   import { afterNavigate, goto } from "$app/navigation";
-  import { Meta } from "svelte-head";
+  import { Meta } from "@rabee-org/svelte-head";
   import { page } from "$app/stores";
   import admin from "$admin/index.js"
   import { onMount } from "svelte";

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -28,7 +28,7 @@ const config = {
     adapter: adapter(),
     alias: {
       '$components': path.resolve('./src/components'),
-      '$modals': path.resolve('./src/components/modals'),
+      '$modals': path.resolve('./src/lib/modals'),
       "$admin": path.resolve('./src/admin'),
       "svelte-admin-components": path.resolve('./src/lib'),
       // '@rabee-org/svelte-admin-components': path.resolve('./src/lib'),

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -28,6 +28,7 @@ const config = {
     adapter: adapter(),
     alias: {
       '$components': path.resolve('./src/components'),
+      '$modals': path.resolve('./src/components/modals'),
       "$admin": path.resolve('./src/admin'),
       "svelte-admin-components": path.resolve('./src/lib'),
       // '@rabee-org/svelte-admin-components': path.resolve('./src/lib'),

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { modalManagerPlugin } from '@rabee-org/svelte-modal-manager/vite'
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [sveltekit(), modalManagerPlugin()],
   define: {
     'process.env': process.env,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,6 +368,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
   integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
 
+"@rabee-org/svelte-modal-manager@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@rabee-org/svelte-modal-manager/-/svelte-modal-manager-0.1.0.tgz#2ddb4c7dd995118435d1972be051e26bf83e2e8a"
+  integrity sha512-2kvxWIAgq9haMpbXZL4WJLlw/1EbOur9so102JW4k1XQg1WvY17CED5RC8LzB9x6Zg2PqrB1KzwVXlj79+YOYQ==
+
 "@rollup/plugin-commonjs@^24.0.0":
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-24.1.0.tgz#79e54bd83bb64396761431eee6c44152ef322100"
@@ -2415,11 +2420,6 @@ svelte-hmr@^0.15.1:
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/svelte-hmr/-/svelte-hmr-0.15.1.tgz#d11d878a0bbb12ec1cba030f580cd2049f4ec86b"
   integrity sha512-BiKB4RZ8YSwRKCNVdNxK/GfY+r4Kjgp9jCLEy0DuqAKfmQtpL38cQK3afdpjw4sqSs4PLi3jIPJIFp259NkZtA==
-
-svelte-modal-manager@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/svelte-modal-manager/-/svelte-modal-manager-0.0.7.tgz#826bafcc519f7aa6cdc667256d3b7918397f048c"
-  integrity sha512-DE5eP5f3xg21Lm4j1+gCthZNK4HAm781CwO/FkyfWLNqx2cEEPoFl3A3Ll/8eo2zPeX7hYCRRkDkE2XhMjSNHw==
 
 svelte-preprocess@^4.10.7:
   version "4.10.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,6 +368,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.7.tgz#ccab5c8f7dc557a52ca3288c10075c9ccd37fff7"
   integrity sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==
 
+"@rabee-org/svelte-head@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@rabee-org/svelte-head/-/svelte-head-0.1.0.tgz#e506b1a909cbabc32b4c284ddefdb3ca9e1397d2"
+  integrity sha512-Uhw5LyzyEmubDonjMMVTauziUlbIF7sj+nFM3S+o19FZ3tMpDKdj5G0L5OTqc9xJVvAopuDdJ7oqfFo96z5rQA==
+
 "@rabee-org/svelte-modal-manager@^0.1.0":
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/@rabee-org/svelte-modal-manager/-/svelte-modal-manager-0.1.0.tgz#2ddb4c7dd995118435d1972be051e26bf83e2e8a"
@@ -2410,11 +2415,6 @@ svelte-check@^3.0.1:
     sade "^1.7.4"
     svelte-preprocess "^5.0.3"
     typescript "^5.0.3"
-
-svelte-head@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/svelte-head/-/svelte-head-0.0.6.tgz#99ef7840a81257ab9c0c7d772cde67563e0d7d8c"
-  integrity sha512-zyyEnl4EQwGtJ1oMUd4b9nnvOeHQFS4NY9cMYjDeL6kyvfYFQSv3lX7b1WJZ2a7eBeC17D7SYp0JS6TYQdKRBA==
 
 svelte-hmr@^0.15.1:
   version "0.15.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,10 +373,10 @@
   resolved "https://registry.yarnpkg.com/@rabee-org/svelte-head/-/svelte-head-0.1.0.tgz#e506b1a909cbabc32b4c284ddefdb3ca9e1397d2"
   integrity sha512-Uhw5LyzyEmubDonjMMVTauziUlbIF7sj+nFM3S+o19FZ3tMpDKdj5G0L5OTqc9xJVvAopuDdJ7oqfFo96z5rQA==
 
-"@rabee-org/svelte-modal-manager@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@rabee-org/svelte-modal-manager/-/svelte-modal-manager-0.1.0.tgz#2ddb4c7dd995118435d1972be051e26bf83e2e8a"
-  integrity sha512-2kvxWIAgq9haMpbXZL4WJLlw/1EbOur9so102JW4k1XQg1WvY17CED5RC8LzB9x6Zg2PqrB1KzwVXlj79+YOYQ==
+"@rabee-org/svelte-modal-manager@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@rabee-org/svelte-modal-manager/-/svelte-modal-manager-0.2.1.tgz#4c8f0ac5b3cc770a7bb4e5aefd8520fff15e5cfa"
+  integrity sha512-zsi7TR41mCjOrGc4iTNMr7TbOuWwozkoRxMVAFb5OSXyysUb0g9Mg+n9KxdmOymUEIY0aBLhKMBmR4qMuFPWhw==
 
 "@rollup/plugin-commonjs@^24.0.0":
   version "24.1.0"


### PR DESCRIPTION
## 対応内容
- modal-managerとsvelte-headを最新のものにアップデート

## 確認方法
- [ ] デグレっていないか確認お願いします

## リンク
- 確認URL ... https://deploy-preview-103--svelte-admin-components.netlify.app/posts/3cfaa348-c31b-4f40-bee4-fcf0c42b78f1
※上記url内カテゴリ箇所でモーダル挙動確認できます
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/HaZsSf2KOS2F6ZUBoGFB/notes/cinpjbq23akg02terhig)
