### PR TITLE
textareaにtoolbarを追加

### DIFF
--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -64,7 +64,16 @@ export default {
           label: "プロフィール",
           type: "textarea",
           opts: {
-            cols: ""
+            toolbar: true,
+            actions: [
+              {
+                label: 'jump',
+                onclick: ({ item, value, actions, insertText }) => {
+                  let text = 'jump を外側から追加する';
+                  insertText(text);
+                },
+              }
+            ],
           }
         },
         {

--- a/src/lib/forms/Markdown.svelte
+++ b/src/lib/forms/Markdown.svelte
@@ -87,6 +87,8 @@
     // 画像以外は弾く
     if (/^image/.test(file.type) === false) return ;
 
+    // TODO: 型定義周り全体的に見直し
+    // @ts-ignore
     let { url, width, height } = await actions.image.upload({
       file,
     });


### PR DESCRIPTION
## 対応内容

- toolbarを追加
- actionsを追加できるように対応

細かい部分はまた改めてリファクタします

## 確認方法

- [ ] toolbarが表示されているか
- [ ] 機能がちゃんと動くか

## リンク

- 確認URL ... https://deploy-preview-105--svelte-admin-components.netlify.app/users

## スクショ
<img width="618" alt="image" src="https://github.com/rabee-inc/svelte-admin-components/assets/63896647/3e76122c-989c-45f1-9a03-9312d15f0b40">

