### PR TITLE
feat: drag and drop時に展開するテキストのoption追加

### DIFF
--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -65,6 +65,12 @@ export default {
           type: "textarea",
           opts: {
             toolbar: true,
+            dragAndDrop: {
+              image: {
+                createTextType: 'html',
+                width: 300,
+              },
+            },
             actions: [
               {
                 label: 'jump',

--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -66,7 +66,7 @@ export default {
           opts: {
             toolbar: true,
             insertImage: {
-              createTextType: 'html',
+              textType: 'html',
               width: 300,
             },
             actions: [

--- a/src/admin/contents/users.js
+++ b/src/admin/contents/users.js
@@ -65,11 +65,9 @@ export default {
           type: "textarea",
           opts: {
             toolbar: true,
-            dragAndDrop: {
-              image: {
-                createTextType: 'html',
-                width: 300,
-              },
+            insertImage: {
+              createTextType: 'html',
+              width: 300,
             },
             actions: [
               {

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -80,7 +80,7 @@
   }
 
   async function createImageText(file) {
-    let ddImageCreateType = schema.opts?.insertImage?.createTextType || 'markdown';
+    let text_type = schema.opts?.insertImage?.textType || 'markdown';
     
     // TODO: 型定義周り全体的に見直し
     // @ts-ignore
@@ -91,10 +91,10 @@
     let imgix_url = getImgixUrl(url, (width >= 2000 ? 2000 : null));
 
     let text = '';
-    if (ddImageCreateType === 'markdown') {
+    if (text_type === 'markdown') {
       text = `![${file.name}](${imgix_url})`;
     }
-    else if (ddImageCreateType === 'html') {
+    else if (text_type === 'html') {
       let _width = schema.opts?.insertImage?.width ? `width="${schema.opts?.insertImage.width}"` : '';
       let _height = schema.opts?.insertImage?.height ? `height="${schema.opts?.insertImage.height}"` : '';
       text = `<img src="${imgix_url}" ${_width} ${_height}>`;

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -15,6 +15,7 @@
   export let textareaElement;
 
   let isShowToolbar = schema.opts?.toolbar;
+  let ddImageCreateType = schema.opts?.dragAndDrop?.image?.createTextType || 'markdown';
 
   let toolbarItems = [
     { id: 'h1', label: 'H1', symbol: '#', type: 'line_head' },
@@ -88,7 +89,17 @@
 
     let imgix_url = getImgixUrl(url, (width >= 2000 ? 2000 : null));
 
-    return `![${file.name}](${imgix_url})`;
+    let text = '';
+    if (ddImageCreateType === 'markdown') {
+      text = `![${file.name}](${imgix_url})`;
+    }
+    else if (ddImageCreateType === 'html') {
+      let _width = schema.opts?.dragAndDrop?.image?.width ? `width="${schema.opts?.dragAndDrop.image.width}"` : '';
+      let _height = schema.opts?.dragAndDrop?.image?.height ? `height="${schema.opts?.dragAndDrop.image.height}"` : '';
+      text = `<img src="${imgix_url}" ${_width} ${_height}>`;
+    }
+
+    return text;
   }
 
   async function onAction(action) {

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -80,7 +80,7 @@
   }
 
   async function createImageText(file) {
-    let ddImageCreateType = schema.opts?.dragAndDrop?.image?.createTextType || 'markdown';
+    let ddImageCreateType = schema.opts?.insertImage?.createTextType || 'markdown';
     
     // TODO: 型定義周り全体的に見直し
     // @ts-ignore
@@ -95,8 +95,8 @@
       text = `![${file.name}](${imgix_url})`;
     }
     else if (ddImageCreateType === 'html') {
-      let _width = schema.opts?.dragAndDrop?.image?.width ? `width="${schema.opts?.dragAndDrop.image.width}"` : '';
-      let _height = schema.opts?.dragAndDrop?.image?.height ? `height="${schema.opts?.dragAndDrop.image.height}"` : '';
+      let _width = schema.opts?.insertImage?.width ? `width="${schema.opts?.insertImage.width}"` : '';
+      let _height = schema.opts?.insertImage?.height ? `height="${schema.opts?.insertImage.height}"` : '';
       text = `<img src="${imgix_url}" ${_width} ${_height}>`;
     }
 

--- a/src/lib/forms/Textarea.svelte
+++ b/src/lib/forms/Textarea.svelte
@@ -15,7 +15,6 @@
   export let textareaElement;
 
   let isShowToolbar = schema.opts?.toolbar;
-  let ddImageCreateType = schema.opts?.dragAndDrop?.image?.createTextType || 'markdown';
 
   let toolbarItems = [
     { id: 'h1', label: 'H1', symbol: '#', type: 'line_head' },
@@ -81,6 +80,8 @@
   }
 
   async function createImageText(file) {
+    let ddImageCreateType = schema.opts?.dragAndDrop?.image?.createTextType || 'markdown';
+    
     // TODO: 型定義周り全体的に見直し
     // @ts-ignore
     let { url, width, height } = await actions.image.upload({


### PR DESCRIPTION
## 対応内容

- drag and dropがマークダウンの展開のみだったので、htmlでも展開できるようオプションを追加

## 確認方法

- [ ] 問題なく動いているか確認

## リンク

- 確認URL ... https://deploy-preview-113--svelte-admin-components.netlify.app/

