### PR TITLE
fix: ArrayでContentの要素を並び替えたときに要素が消えてしまうのを修正

### DIFF
--- a/src/lib/forms/Content.svelte
+++ b/src/lib/forms/Content.svelte
@@ -56,7 +56,7 @@
           div.fs10.text-danger ※{schema.opts.caution}
     div.f.fm
       +if('contentItem')
-        div.col8.mr16 {getByPath(contentItem, schema.opts.label_key)}
-      div
+        div.mr16 {getByPath(contentItem, schema.opts.label_key)}
+      div.flex-fixed
         button.button(type='button', on:click='{openContentModal}') 選択する
 </template>

--- a/src/lib/forms/Content.svelte
+++ b/src/lib/forms/Content.svelte
@@ -35,16 +35,12 @@
 
     modal.$on('select', (e) => {
       contentItem = e.detail.item;
-
+      value = getByPath(contentItem, schema.opts.value_key);
       dispatch('change');
       modal.close();
     });
   };
 
-  // svelte-ignore unused-export-let
-  export let getValue = () => {
-    return contentItem ? getByPath(contentItem, schema.opts.value_key) : null;
-  };
 </script>
 
 <template lang='pug'>
@@ -60,7 +56,7 @@
           div.fs10.text-danger ※{schema.opts.caution}
     div.f.fm
       +if('contentItem')
-        div.mr16 {getByPath(contentItem, schema.opts.label_key)}
+        div.col8.mr16 {getByPath(contentItem, schema.opts.label_key)}
       div
         button.button(type='button', on:click='{openContentModal}') 選択する
 </template>


### PR DESCRIPTION
## 対応内容

- Arrayで並べたContentを並び替え・追加・削除したときに、すべての要素のvalueが消えてしまうのを修正

## 確認方法

- [ ] 規約選択箇所で、要素を並び替え・追加・削除しても他のものが消えないか確認

## リンク

- 確認URL ... http://localhost:3000/events/nintendolive2024/entry_frames/super_smash_bros_team_elementary
- [alog](https://alog.team/workspaces/uRFSioAqv62eVHwR8_li0crEDWtc8irtkQh1ry55YiE/projects/xT3pETv7ovlpbSDY0tnp/notes/crqfm0i9io6g02tl9820?view=list)

## スクショ
